### PR TITLE
Make sure code components can run against React in production mode

### DIFF
--- a/packages/toolpad-app/src/createRuntimeState.tsx
+++ b/packages/toolpad-app/src/createRuntimeState.tsx
@@ -12,6 +12,7 @@ export function compileModule(src: string, filename: string): CompiledModule {
 
   try {
     compiled = transform(src, {
+      production: true,
       transforms: ['jsx', 'typescript', 'imports'],
       filePath: filename,
       jsxRuntime: 'classic',


### PR DESCRIPTION
This got introduced by not rebasing https://github.com/mui/mui-toolpad/pull/1294 after merging https://github.com/mui/mui-toolpad/pull/1332

No extra tests required, this was caught by CI on master