### PR TITLE
Improve errors in Chart component

### DIFF
--- a/packages/toolpad-app/src/runtime/evalJsBindings.ts
+++ b/packages/toolpad-app/src/runtime/evalJsBindings.ts
@@ -171,12 +171,12 @@ export default function evalJsBindings(
     if (expression) {
       const computed = computationStatuses.get(expression);
       if (computed) {
-        if (computed.result) {
+        if (!computed.result) {
+          throw new Error(`Cycle detected "${scopePath}"`);
+        } else if (!computed.result.error) {
           // From cache
           return computed.result;
         }
-
-        throw new Error(`Cycle detected "${scopePath}"`);
       }
 
       // use null to mark as "computing"

--- a/packages/toolpad-components/src/Chart.tsx
+++ b/packages/toolpad-components/src/Chart.tsx
@@ -171,8 +171,8 @@ function Chart({ data = [], loading, error, sx }: ChartProps) {
 
   return (
     <Box sx={{ ...sx, position: 'relative', height: '100%', width: '100%' }} aria-busy={loading}>
-      {displayError ? <ErrorOverlay error={displayError} /> : null}
-      {loading && !error ? (
+      {displayError && !loading ? <ErrorOverlay error={displayError} /> : null}
+      {loading ? (
         <div
           style={{
             position: 'absolute',

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -1266,6 +1266,7 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
     <LicenseInfoProvider info={LICENSE_INFO}>
       <Box ref={ref} sx={{ ...sx, width: '100%', height: '100%', position: 'relative' }}>
         <ErrorBoundary fallbackRender={dataGridFallbackRender} resetKeys={[rows]}>
+          {errorProp ? <ErrorOverlay error={errorProp} /> : null}
           <SetActionResultContext.Provider value={setActionResult}>
             <DataGridPro
               apiRef={apiRef}

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -1266,7 +1266,6 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
     <LicenseInfoProvider info={LICENSE_INFO}>
       <Box ref={ref} sx={{ ...sx, width: '100%', height: '100%', position: 'relative' }}>
         <ErrorBoundary fallbackRender={dataGridFallbackRender} resetKeys={[rows]}>
-          {errorProp ? <ErrorOverlay error={errorProp} /> : null}
           <SetActionResultContext.Provider value={setActionResult}>
             <DataGridPro
               apiRef={apiRef}


### PR DESCRIPTION
While looking a bit into propagating query errors to component binding results, ran into some semi-related issues in charts.

**Edit**: I moved this back into draft as I thought the fix wouldn't break any tests but it does. This logic is a bit complicated, I wasn't able to find a good solution so far / get to the root of the issue.

**Before:**
- Charts example was showing errors in some charts before loading

https://github.com/mui/mui-toolpad/assets/10789765/4f0d70a5-c86c-4a2a-b04a-7d4009f894f0

**After:**
- Charts load without errors

https://github.com/mui/mui-toolpad/assets/10789765/669c2f7c-8703-4233-b996-e7452520e8f2

