### PR TITLE
[website] Add missing <Head>

### DIFF
--- a/docs/pages/toolpad/index.js
+++ b/docs/pages/toolpad/index.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Head from 'docs/src/modules/components/Head';
 import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import Divider from '@mui/material/Divider';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -14,6 +15,11 @@ import StudioIntro from '../../src/components/landing/StudioIntro';
 export default function Home() {
   return (
     <BrandingCssVarsProvider>
+      <Head
+        title="Toolpad Core: Components for React admin panels"
+        description="Toolpad Core offers the components needed for your next admin panel and internal tools project."
+        // card="/static/toolpad/marketing/toolpad-og.jpg"
+      />
       <CssBaseline />
       <AppHeaderBanner />
       <AppHeader gitHubRepository="https://github.com/mui/mui-toolpad" />

--- a/docs/pages/toolpad/studio/index.js
+++ b/docs/pages/toolpad/studio/index.js
@@ -31,7 +31,7 @@ export default function Home() {
     <BrandingCssVarsProvider>
       <Head
         title="Toolpad: Low-code admin builder"
-        description="Build apps with Material UI components, connect to data sources, APIs and build your internal tools 10x faster. Open-source and powered by MUI."
+        description="Build apps with Material UI components, connect to data sources, APIs and build your internal tools 10x faster. Open-source and powered by Material UI."
         card="/static/toolpad/marketing/toolpad-og.jpg"
       />
       <NoSsr>

--- a/docs/src/components/landing/BuiltWith.js
+++ b/docs/src/components/landing/BuiltWith.js
@@ -30,10 +30,10 @@ const content = [
       'Next.js sets the industry standard for modern React applications. Building over it is a leverage that makes Toolpad efficient.',
   },
   {
-    icon: <img src="https://mui.com/static/logo.png" width={30} alt="MUI" />,
-    title: 'MUI',
+    icon: <img src="https://mui.com/static/logo.png" width={30} alt="Material UI" />,
+    title: 'Material UI',
     description:
-      'A tight integration with MUI ensures you get all the latest features from our list of Material UI components.',
+      'A tight integration with Material UI ensures you get all the latest features from our list of Material UI components.',
   },
 ];
 


### PR DESCRIPTION
https://master--mui-toolpad-docs.netlify.app/toolpad/ has no title, og:image, description, etc.
This was removed in #3868. I thought I would open a PR directly, it was as fast as reporting it.

---

Side observations:

- We need to create og images for toolpad core
- The h1 is truncated in the first HTML render: "Full stack components for React"