### PR TITLE
[code-infra] Update path-to-regexp to 6.3.0

### DIFF
--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -59,9 +59,10 @@
     "@mui/lab": "6.0.0-beta.10",
     "@mui/utils": "6.1.1",
     "@toolpad/utils": "workspace:*",
+    "@vitejs/plugin-react": "4.3.1",
     "client-only": "^0.0.1",
     "invariant": "2.2.4",
-    "path-to-regexp": "6.2.2",
+    "path-to-regexp": "6.3.0",
     "prop-types": "15.8.1"
   },
   "devDependencies": {

--- a/packages/toolpad-core/src/nextjs/AppProvider.test.tsx
+++ b/packages/toolpad-core/src/nextjs/AppProvider.test.tsx
@@ -8,7 +8,7 @@ import { render, screen } from '@testing-library/react';
 import { AppProvider } from './AppProvider';
 import { Router } from '../AppProvider';
 
-vi.mock('./nextNavigation', () => {
+vi.mock('next/navigation', () => {
   const searchParams = new URLSearchParams();
   const push = () => {};
   const replace = () => {};
@@ -20,9 +20,9 @@ vi.mock('./nextNavigation', () => {
   };
 });
 
-vi.mock('./nextRouter', () => ({ useRouter: () => null }));
+vi.mock('next/router', () => ({ useRouter: () => null }));
 
-vi.mock('./nextCompatRouter', () => ({ useRouter: () => null }));
+vi.mock('next/compat/router', () => ({ useRouter: () => null }));
 
 interface RouterTestProps {
   children: React.ReactNode;

--- a/packages/toolpad-core/src/nextjs/AppProvider.tsx
+++ b/packages/toolpad-core/src/nextjs/AppProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useRouter } from './nextCompatRouter';
+import { useRouter } from 'next/compat/router';
 import { AppProviderNextApp } from './AppProviderNextApp';
 import { AppProviderNextPages } from './AppProviderNextPages';
 import type { AppProviderProps } from '../AppProvider';

--- a/packages/toolpad-core/src/nextjs/AppProviderNextApp.tsx
+++ b/packages/toolpad-core/src/nextjs/AppProviderNextApp.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { usePathname, useSearchParams, useRouter } from './nextNavigation';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 import { AppProvider } from '../AppProvider';
 import type { AppProviderProps, Navigate, Router } from '../AppProvider';
 

--- a/packages/toolpad-core/src/nextjs/AppProviderNextPages.tsx
+++ b/packages/toolpad-core/src/nextjs/AppProviderNextPages.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { asArray } from '@toolpad/utils/collections';
-import { useRouter } from './nextRouter';
+import { useRouter } from 'next/router';
 import { AppProvider } from '../AppProvider';
 import type { AppProviderProps, Navigate, Router } from '../AppProvider';
 

--- a/packages/toolpad-core/src/nextjs/nextCompatRouter.ts
+++ b/packages/toolpad-core/src/nextjs/nextCompatRouter.ts
@@ -1,1 +1,0 @@
-export * from 'next/compat/router';

--- a/packages/toolpad-core/src/nextjs/nextNavigation.ts
+++ b/packages/toolpad-core/src/nextjs/nextNavigation.ts
@@ -1,1 +1,0 @@
-export * from 'next/navigation';

--- a/packages/toolpad-core/src/nextjs/nextRouter.ts
+++ b/packages/toolpad-core/src/nextjs/nextRouter.ts
@@ -1,1 +1,0 @@
-export * from 'next/router';

--- a/packages/toolpad-core/vitest.config.mts
+++ b/packages/toolpad-core/vitest.config.mts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     setupFiles: ['../../test/setupVitest.ts', '@testing-library/jest-dom/vitest'],
     browser: {
@@ -18,14 +20,5 @@ export default defineConfig({
       reportsDirectory: './.coverage',
       reporter: ['text', 'lcov'],
     },
-  },
-  resolve: {
-    alias: [
-      {
-        // FIXME(https://github.com/mui/material-ui/issues/35233)
-        find: /^@mui\/icons-material\/(?!esm\/)([^/]*)/,
-        replacement: '@mui/icons-material/esm/$1',
-      },
-    ],
   },
 });

--- a/packages/toolpad-studio/package.json
+++ b/packages/toolpad-studio/package.json
@@ -119,7 +119,7 @@
     "node-fetch": "2.7.0",
     "node-fetch-har": "1.0.1",
     "open-editor": "5.0.0",
-    "path-to-regexp": "7.1.0",
+    "path-to-regexp": "6.3.0",
     "perf-cascade": "3.0.3",
     "pg": "8.12.0",
     "piscina": "4.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,6 +616,9 @@ importers:
       '@toolpad/utils':
         specifier: workspace:*
         version: link:../toolpad-utils
+      '@vitejs/plugin-react':
+        specifier: 4.3.1
+        version: 4.3.1(vite@5.4.6(@types/node@22.5.5)(terser@5.31.1))
       client-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -623,8 +626,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       path-to-regexp:
-        specifier: 6.2.2
-        version: 6.2.2
+        specifier: 6.3.0
+        version: 6.3.0
       prop-types:
         specifier: 15.8.1
         version: 15.8.1
@@ -865,8 +868,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0
       path-to-regexp:
-        specifier: 7.1.0
-        version: 7.1.0
+        specifier: 6.3.0
+        version: 6.3.0
       perf-cascade:
         specifier: 3.0.3
         version: 3.0.3
@@ -8202,12 +8205,8 @@ packages:
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
-  path-to-regexp@6.2.2:
-    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
-
-  path-to-regexp@7.1.0:
-    resolution: {integrity: sha512-ZToe+MbUF4lBqk6dV8GKot4DKfzrxXsplOddH8zN3YK+qw9/McvP7+4ICjZvOne0jQhN4eJwHsX6tT0Ns19fvw==}
-    engines: {node: '>=16'}
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.1.0:
     resolution: {integrity: sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==}
@@ -17847,7 +17846,7 @@ snapshots:
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.2
-      path-to-regexp: 6.2.2
+      path-to-regexp: 6.3.0
       strict-event-emitter: 0.5.1
       type-fest: 4.20.1
       yargs: 17.7.2
@@ -17959,7 +17958,7 @@ snapshots:
       '@sinonjs/fake-timers': 11.2.2
       '@sinonjs/text-encoding': 0.7.2
       just-extend: 6.2.0
-      path-to-regexp: 6.2.2
+      path-to-regexp: 6.3.0
 
   node-addon-api@3.2.1:
     optional: true
@@ -18484,9 +18483,7 @@ snapshots:
 
   path-to-regexp@0.1.10: {}
 
-  path-to-regexp@6.2.2: {}
-
-  path-to-regexp@7.1.0: {}
+  path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.1.0: {}
 


### PR DESCRIPTION
Update `path-to-regexp` to 6.3.0 which contains a fix for https://github.com/advisories/GHSA-9wv6-86v2-598j, but doesn't suffer from https://github.com/vitest-dev/vitest/issues/6540

Few fixes to the setup I'm passing along
* Add react plugin to vite
* Clean up the workaround for mocking of external modules during vitest browser beta  (this was causing flakyness)
* Remove the alias for icon esm. This has been fixed in `@mui/icons-material@6.1.0`

Closes https://github.com/mui/toolpad/issues/4125