### PR TITLE
[FIX] docs: input.label in SlotsSignIn

### DIFF
--- a/docs/data/toolpad/core/components/sign-in-page/SlotsSignIn.js
+++ b/docs/data/toolpad/core/components/sign-in-page/SlotsSignIn.js
@@ -21,7 +21,7 @@ function CustomEmailField() {
   return (
     <TextField
       id="input-with-icon-textfield"
-      label="Username"
+      label="Email"
       name="email"
       type="email"
       size="small"

--- a/docs/data/toolpad/core/components/sign-in-page/SlotsSignIn.tsx
+++ b/docs/data/toolpad/core/components/sign-in-page/SlotsSignIn.tsx
@@ -21,7 +21,7 @@ function CustomEmailField() {
   return (
     <TextField
       id="input-with-icon-textfield"
-      label="Username"
+      label="Email"
       name="email"
       type="email"
       size="small"


### PR DESCRIPTION
The "input" component had the label="Username", however with email and name="email" type validation.

I corrected the label to represent the content, which is "email"

https://deploy-preview-4157--mui-toolpad-docs.netlify.app/toolpad/core/react-sign-in-page/#slots

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I've read and followed the [contributing guide](https://github.com/mui/toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [x] I've updated the relevant documentation for any new or updated feature.
- [ ] I've linked relevant GitHub issue with "Closes #<issue id>".
- [ ] I've added a visual demonstration in the form of a screenshot or video.
