### PR TITLE
[core] Increase the minimum Node.js version support to 14.0.0

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -75,20 +75,20 @@ samsung 22
 # snapshot of `npx browserslist "maintained node versions"`
 # On update check all #stable-snapshot markers
 [node]
-node 12.0
+node 14.0
 
 # same as `node`
 [coverage]
-node 12.0
+node 14.0
 
 # same as `node`
 [development]
-node 12.0
+node 14.0
 
 # same as `node`
 [test]
-node 12.0
+node 14.0
 
 # same as `node`
 [benchmark]
-node 12.0
+node 14.0


### PR DESCRIPTION
Same minimum version increase as in https://github.com/mui/material-ui/pull/42920, from v12.0.0 to v14.0.0. No reason for the version to be different.