### PR TITLE
[website] Toolpad Core website was linking to Toolpad Studio examples 

### DIFF
--- a/docs/src/components/landing/Examples.js
+++ b/docs/src/components/landing/Examples.js
@@ -159,7 +159,7 @@ export default function Examples() {
               <Typography variant="body" color="text.secondary" textAlign="center">
                 Learn how to build these and many other apps using Toolpad Core!
               </Typography>
-              <Link href="/toolpad/studio/examples/" variant="body" sx={{ mt: 1 }}>
+              <Link href="/toolpad/core/introduction/examples/" variant="body" sx={{ mt: 1 }}>
                 Check out docs
                 <KeyboardArrowRightRounded fontSize="small" />
               </Link>

--- a/docs/src/components/landing/StudioIntro.js
+++ b/docs/src/components/landing/StudioIntro.js
@@ -69,7 +69,7 @@ export default function StudioIntro() {
             <CardMedia
               component="a"
               image="https://mui.com/static/toolpad/docs/studio/examples/npm-stats.png"
-              href="https://mui-toolpad-npm-stats-production.up.railway.app/prod/pages/page"
+              href="/toolpad/studio/examples/npm-stats/"
               target="_blank"
               rel="nofollow"
               sx={(theme) => ({


### PR DESCRIPTION
Fixed the link in 'Check out docs' button of the Examples section.
https://deploy-preview-4238--mui-toolpad-docs.netlify.app/toolpad/