### PR TITLE
Move vitest to dev dependency in `@toolpad/utils`

### DIFF
--- a/packages/toolpad-utils/package.json
+++ b/packages/toolpad-utils/package.json
@@ -62,7 +62,6 @@
     "prettier": "3.3.3",
     "react-is": "18.3.1",
     "title": "3.5.3",
-    "vitest": "2.1.2",
     "yaml": "2.5.1",
     "yaml-diff-patch": "2.0.0"
   },
@@ -71,6 +70,7 @@
     "@types/invariant": "2.2.37",
     "@types/react": "18.3.11",
     "@types/react-is": "18.3.0",
-    "@types/title": "3.4.3"
+    "@types/title": "3.4.3",
+    "vitest": "2.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,7 @@ importers:
         version: 7.37.1(eslint@8.57.1)
       eslint-plugin-react-compiler:
         specifier: latest
-        version: 0.0.0-experimental-fa06e2c-20241014(eslint@8.57.1)
+        version: 0.0.0-experimental-605e95c-20241015(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: 4.6.2
         version: 4.6.2(eslint@8.57.1)
@@ -1173,9 +1173,6 @@ importers:
       title:
         specifier: 3.5.3
         version: 3.5.3
-      vitest:
-        specifier: 2.1.2
-        version: 2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(jsdom@25.0.1)(msw@2.4.9(typescript@5.6.2))(terser@5.34.1)
       yaml:
         specifier: 2.5.1
         version: 2.5.1
@@ -1198,6 +1195,9 @@ importers:
       '@types/title':
         specifier: 3.4.3
         version: 3.4.3
+      vitest:
+        specifier: 2.1.2
+        version: 2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(jsdom@25.0.1)(msw@2.4.9(typescript@5.6.2))(terser@5.34.1)
 
   playground/nextjs:
     devDependencies:
@@ -2013,7 +2013,7 @@ packages:
     resolution: {integrity: sha512-GjV0/mUEEXpi1U5ZgDprMRRgajGMRW3G5FjMr5KLKD8nT2fTG8+h/klV3+6Dm5739QE+K5+2e91qFKAYI3pmRg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.25.8
+      '@babel/core': ^7.0.0-0
 
   '@babel/preset-typescript@7.25.7':
     resolution: {integrity: sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==}
@@ -2083,7 +2083,7 @@ packages:
   '@docsearch/react@3.6.2':
     resolution: {integrity: sha512-rtZce46OOkVflCQH71IdbXSFK+S8iJZlUF56XBW5rIgx/eG5qoomC7Ag3anZson1bBac/JFQn7XOBfved/IMRA==}
     peerDependencies:
-      '@types/react': ^18.3.11
+      '@types/react': '>= 16.8.0 < 19.0.0'
       react: '>= 16.8.0 < 19.0.0'
       react-dom: '>= 16.8.0 < 19.0.0'
       search-insights: '>= 1 < 3'
@@ -2899,7 +2899,7 @@ packages:
     resolution: {integrity: sha512-P0E7ZrxOuyYqBvVv9w8k7wm+Xzx/KRu+BGgFcR2htTsGCpJNQJCSUXNUZ50MUmSU9hzqhwbQWNXhV1MBTl6F7A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@types/react': ^18.3.11
+      '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
@@ -5991,8 +5991,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-react-compiler@0.0.0-experimental-fa06e2c-20241014:
-    resolution: {integrity: sha512-tHntZz8Kx/6RgCLn7aDGfBQizqTUUfHEDaBcrvJi1GhKzgDxmAbdn85Y6z8eGSh4s0gufNWyO9WRCYLf0hP0ow==}
+  eslint-plugin-react-compiler@0.0.0-experimental-605e95c-20241015:
+    resolution: {integrity: sha512-YefQd/ZGYx5UWRRusUyf8PDmf2MPHrOGj2vZQbhJc9zUoGD3RGEJueTsIl4EZTGXjJOIe/TnuznDAa1laUyMYQ==}
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     peerDependencies:
       eslint: '>=7'
@@ -15780,7 +15780,7 @@ snapshots:
       globals: 13.24.0
       rambda: 7.5.0
 
-  eslint-plugin-react-compiler@0.0.0-experimental-fa06e2c-20241014(eslint@8.57.1):
+  eslint-plugin-react-compiler@0.0.0-experimental-605e95c-20241015(eslint@8.57.1):
     dependencies:
       '@babel/core': 7.25.8
       '@babel/parser': 7.25.8


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/security/dependabot/181