### PR TITLE
Update React Router example configs

### DIFF
--- a/docs/data/toolpad/core/introduction/ReactRouter.js
+++ b/docs/data/toolpad/core/introduction/ReactRouter.js
@@ -100,11 +100,11 @@ function ReactRouter(props) {
               Component: Layout,
               children: [
                 {
-                  path: '/',
+                  path: '',
                   Component: DashboardPage,
                 },
                 {
-                  path: '/orders',
+                  path: 'orders',
                   Component: OrdersPage,
                 },
               ],

--- a/docs/data/toolpad/core/introduction/ReactRouter.tsx
+++ b/docs/data/toolpad/core/introduction/ReactRouter.tsx
@@ -104,11 +104,11 @@ export default function ReactRouter(props: DemoProps) {
               Component: Layout,
               children: [
                 {
-                  path: '/',
+                  path: '',
                   Component: DashboardPage,
                 },
                 {
-                  path: '/orders',
+                  path: 'orders',
                   Component: OrdersPage,
                 },
               ],

--- a/docs/data/toolpad/core/introduction/ReactRouter.tsx.preview
+++ b/docs/data/toolpad/core/introduction/ReactRouter.tsx.preview
@@ -9,11 +9,11 @@ const router = React.useMemo(
             Component: Layout,
             children: [
               {
-                path: '/',
+                path: '',
                 Component: DashboardPage,
               },
               {
-                path: '/orders',
+                path: 'orders',
                 Component: OrdersPage,
               },
             ],

--- a/docs/data/toolpad/core/introduction/integration.md
+++ b/docs/data/toolpad/core/introduction/integration.md
@@ -815,11 +815,11 @@ const router = createBrowserRouter([
         Component: Layout,
         children: [
           {
-            path: '/',
+            path: '',
             Component: DashboardPage,
           },
           {
-            path: '/orders',
+            path: 'orders',
             Component: OrdersPage,
           },
         ],

--- a/examples/core-vite/src/main.tsx
+++ b/examples/core-vite/src/main.tsx
@@ -15,11 +15,11 @@ const router = createBrowserRouter([
         Component: Layout,
         children: [
           {
-            path: '/',
+            path: '',
             Component: DashboardPage,
           },
           {
-            path: '/orders',
+            path: 'orders',
             Component: OrdersPage,
           },
         ],

--- a/playground/vite/src/main.tsx
+++ b/playground/vite/src/main.tsx
@@ -15,11 +15,11 @@ const router = createBrowserRouter([
         Component: Layout,
         children: [
           {
-            path: '/',
+            path: '',
             Component: DashboardPage,
           },
           {
-            path: '/orders',
+            path: 'orders',
             Component: OrdersPage,
           },
         ],


### PR DESCRIPTION
Update all React Router example configs to me less confusing and more extensible.
It seems that the nested paths should not use a `/` in the beginning in these new React Router configurations in `createBrowserRouter`.