### PR TITLE
Allow theme switcher override with slots

### DIFF
--- a/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomThemeSwitcher.js
+++ b/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomThemeSwitcher.js
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Box from '@mui/material/Box';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import IconButton from '@mui/material/IconButton';
+import Popover from '@mui/material/Popover';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { createTheme, useColorScheme } from '@mui/material/styles';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { AppProvider } from '@toolpad/core/AppProvider';
+import { DashboardLayout } from '@toolpad/core/DashboardLayout';
+import { useDemoRouter } from '@toolpad/core/internal';
+
+const NAVIGATION = [
+  {
+    kind: 'header',
+    title: 'Main items',
+  },
+  {
+    segment: 'dashboard',
+    title: 'Dashboard',
+    icon: <DashboardIcon />,
+  },
+  {
+    segment: 'orders',
+    title: 'Orders',
+    icon: <ShoppingCartIcon />,
+  },
+];
+
+const demoTheme = createTheme({
+  cssVariables: {
+    colorSchemeSelector: 'data-toolpad-color-scheme',
+  },
+  colorSchemes: { light: true, dark: true },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 600,
+      lg: 1200,
+      xl: 1536,
+    },
+  },
+});
+
+function DemoPageContent({ pathname }) {
+  return (
+    <Box
+      sx={{
+        py: 4,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+      }}
+    >
+      <Typography>Dashboard content for {pathname}</Typography>
+    </Box>
+  );
+}
+
+DemoPageContent.propTypes = {
+  pathname: PropTypes.string.isRequired,
+};
+
+function CustomThemeSwitcher() {
+  const { setMode } = useColorScheme();
+
+  const handleThemeChange = React.useCallback(
+    (event) => {
+      setMode(event.target.value);
+    },
+    [setMode],
+  );
+
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  const [menuAnchorEl, setMenuAnchorEl] = React.useState(null);
+
+  const toggleMenu = React.useCallback(
+    (event) => {
+      setMenuAnchorEl(isMenuOpen ? null : event.currentTarget);
+      setIsMenuOpen((previousIsMenuOpen) => !previousIsMenuOpen);
+    },
+    [isMenuOpen],
+  );
+
+  return (
+    <React.Fragment>
+      <Tooltip title="Settings" enterDelay={1000}>
+        <div>
+          <IconButton type="button" aria-label="settings" onClick={toggleMenu}>
+            <SettingsIcon />
+          </IconButton>
+        </div>
+      </Tooltip>
+      <Popover
+        open={isMenuOpen}
+        anchorEl={menuAnchorEl}
+        onClose={toggleMenu}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        disableAutoFocus
+      >
+        <Box sx={{ p: 2 }}>
+          <FormControl>
+            <FormLabel id="custom-theme-switcher-label">Theme</FormLabel>
+            <RadioGroup
+              aria-labelledby="custom-theme-switcher-label"
+              defaultValue="system"
+              name="custom-theme-switcher"
+              onChange={handleThemeChange}
+            >
+              <FormControlLabel value="light" control={<Radio />} label="Light" />
+              <FormControlLabel value="system" control={<Radio />} label="System" />
+              <FormControlLabel value="dark" control={<Radio />} label="Dark" />
+            </RadioGroup>
+          </FormControl>
+        </Box>
+      </Popover>
+    </React.Fragment>
+  );
+}
+
+function DashboardLayoutCustomThemeSwitcher(props) {
+  const { window } = props;
+
+  const router = useDemoRouter('/dashboard');
+
+  // Remove this const when copying and pasting into your project.
+  const demoWindow = window !== undefined ? window() : undefined;
+
+  return (
+    <AppProvider
+      navigation={NAVIGATION}
+      router={router}
+      theme={demoTheme}
+      window={demoWindow}
+    >
+      <DashboardLayout
+        slots={{
+          toolbarActions: CustomThemeSwitcher,
+        }}
+      >
+        <DemoPageContent pathname={router.pathname} />
+      </DashboardLayout>
+    </AppProvider>
+  );
+}
+
+DashboardLayoutCustomThemeSwitcher.propTypes = {
+  /**
+   * Injected by the documentation to work in an iframe.
+   * Remove this when copying and pasting into your project.
+   */
+  window: PropTypes.func,
+};
+
+export default DashboardLayoutCustomThemeSwitcher;

--- a/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomThemeSwitcher.tsx
+++ b/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomThemeSwitcher.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import IconButton from '@mui/material/IconButton';
+import Popover from '@mui/material/Popover';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { createTheme, useColorScheme } from '@mui/material/styles';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { AppProvider, type Navigation } from '@toolpad/core/AppProvider';
+import { DashboardLayout } from '@toolpad/core/DashboardLayout';
+import { useDemoRouter } from '@toolpad/core/internal';
+
+const NAVIGATION: Navigation = [
+  {
+    kind: 'header',
+    title: 'Main items',
+  },
+  {
+    segment: 'dashboard',
+    title: 'Dashboard',
+    icon: <DashboardIcon />,
+  },
+  {
+    segment: 'orders',
+    title: 'Orders',
+    icon: <ShoppingCartIcon />,
+  },
+];
+
+const demoTheme = createTheme({
+  cssVariables: {
+    colorSchemeSelector: 'data-toolpad-color-scheme',
+  },
+  colorSchemes: { light: true, dark: true },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 600,
+      lg: 1200,
+      xl: 1536,
+    },
+  },
+});
+
+function DemoPageContent({ pathname }: { pathname: string }) {
+  return (
+    <Box
+      sx={{
+        py: 4,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+      }}
+    >
+      <Typography>Dashboard content for {pathname}</Typography>
+    </Box>
+  );
+}
+
+function CustomThemeSwitcher() {
+  const { setMode } = useColorScheme();
+
+  const handleThemeChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setMode(event.target.value as 'light' | 'dark' | 'system');
+    },
+    [setMode],
+  );
+
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(null);
+
+  const toggleMenu = React.useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      setMenuAnchorEl(isMenuOpen ? null : event.currentTarget);
+      setIsMenuOpen((previousIsMenuOpen) => !previousIsMenuOpen);
+    },
+    [isMenuOpen],
+  );
+
+  return (
+    <React.Fragment>
+      <Tooltip title="Settings" enterDelay={1000}>
+        <div>
+          <IconButton type="button" aria-label="settings" onClick={toggleMenu}>
+            <SettingsIcon />
+          </IconButton>
+        </div>
+      </Tooltip>
+      <Popover
+        open={isMenuOpen}
+        anchorEl={menuAnchorEl}
+        onClose={toggleMenu}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        disableAutoFocus
+      >
+        <Box sx={{ p: 2 }}>
+          <FormControl>
+            <FormLabel id="custom-theme-switcher-label">Theme</FormLabel>
+            <RadioGroup
+              aria-labelledby="custom-theme-switcher-label"
+              defaultValue="system"
+              name="custom-theme-switcher"
+              onChange={handleThemeChange}
+            >
+              <FormControlLabel value="light" control={<Radio />} label="Light" />
+              <FormControlLabel value="system" control={<Radio />} label="System" />
+              <FormControlLabel value="dark" control={<Radio />} label="Dark" />
+            </RadioGroup>
+          </FormControl>
+        </Box>
+      </Popover>
+    </React.Fragment>
+  );
+}
+
+interface DemoProps {
+  /**
+   * Injected by the documentation to work in an iframe.
+   * Remove this when copying and pasting into your project.
+   */
+  window?: () => Window;
+}
+
+export default function DashboardLayoutCustomThemeSwitcher(props: DemoProps) {
+  const { window } = props;
+
+  const router = useDemoRouter('/dashboard');
+
+  // Remove this const when copying and pasting into your project.
+  const demoWindow = window !== undefined ? window() : undefined;
+
+  return (
+    <AppProvider
+      navigation={NAVIGATION}
+      router={router}
+      theme={demoTheme}
+      window={demoWindow}
+    >
+      <DashboardLayout
+        slots={{
+          toolbarActions: CustomThemeSwitcher,
+        }}
+      >
+        <DemoPageContent pathname={router.pathname} />
+      </DashboardLayout>
+    </AppProvider>
+  );
+}

--- a/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomThemeSwitcher.tsx.preview
+++ b/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomThemeSwitcher.tsx.preview
@@ -1,7 +1,6 @@
 <DashboardLayout
   slots={{
-    toolbarActions: ToolbarActionsSearch,
-    sidebarFooter: SidebarFooter,
+    toolbarActions: CustomThemeSwitcher,
   }}
 >
   <DemoPageContent pathname={router.pathname} />

--- a/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutSlots.js
+++ b/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutSlots.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -10,7 +11,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import SearchIcon from '@mui/icons-material/Search';
 import { AppProvider } from '@toolpad/core/AppProvider';
-import { DashboardLayout } from '@toolpad/core/DashboardLayout';
+import { DashboardLayout, ThemeSwitcher } from '@toolpad/core/DashboardLayout';
 import { useDemoRouter } from '@toolpad/core/internal';
 
 const NAVIGATION = [
@@ -66,9 +67,9 @@ DemoPageContent.propTypes = {
   pathname: PropTypes.string.isRequired,
 };
 
-function Search() {
+function ToolbarActionsSearch() {
   return (
-    <React.Fragment>
+    <Stack direction="row">
       <Tooltip title="Search" enterDelay={1000}>
         <div>
           <IconButton
@@ -98,7 +99,8 @@ function Search() {
         }}
         sx={{ display: { xs: 'none', md: 'inline-block' }, mr: 1 }}
       />
-    </React.Fragment>
+      <ThemeSwitcher />
+    </Stack>
   );
 }
 
@@ -133,7 +135,10 @@ function DashboardLayoutSlots(props) {
       window={demoWindow}
     >
       <DashboardLayout
-        slots={{ toolbarActions: Search, sidebarFooter: SidebarFooter }}
+        slots={{
+          toolbarActions: ToolbarActionsSearch,
+          sidebarFooter: SidebarFooter,
+        }}
       >
         <DemoPageContent pathname={router.pathname} />
       </DashboardLayout>

--- a/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutSlots.tsx
+++ b/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutSlots.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -11,6 +12,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import { AppProvider, type Navigation } from '@toolpad/core/AppProvider';
 import {
   DashboardLayout,
+  ThemeSwitcher,
   type SidebarFooterProps,
 } from '@toolpad/core/DashboardLayout';
 import { useDemoRouter } from '@toolpad/core/internal';
@@ -64,9 +66,9 @@ function DemoPageContent({ pathname }: { pathname: string }) {
   );
 }
 
-function Search() {
+function ToolbarActionsSearch() {
   return (
-    <React.Fragment>
+    <Stack direction="row">
       <Tooltip title="Search" enterDelay={1000}>
         <div>
           <IconButton
@@ -96,7 +98,8 @@ function Search() {
         }}
         sx={{ display: { xs: 'none', md: 'inline-block' }, mr: 1 }}
       />
-    </React.Fragment>
+      <ThemeSwitcher />
+    </Stack>
   );
 }
 
@@ -135,7 +138,10 @@ export default function DashboardLayoutSlots(props: DemoProps) {
       window={demoWindow}
     >
       <DashboardLayout
-        slots={{ toolbarActions: Search, sidebarFooter: SidebarFooter }}
+        slots={{
+          toolbarActions: ToolbarActionsSearch,
+          sidebarFooter: SidebarFooter,
+        }}
       >
         <DemoPageContent pathname={router.pathname} />
       </DashboardLayout>

--- a/docs/data/toolpad/core/components/dashboard-layout/dashboard-layout.md
+++ b/docs/data/toolpad/core/components/dashboard-layout/dashboard-layout.md
@@ -1,7 +1,7 @@
 ---
 productId: toolpad-core
 title: Dashboard Layout
-components: AppProvider, DashboardLayout, Account
+components: AppProvider, DashboardLayout, ToolbarActions, ThemeSwitcher, Account
 ---
 
 # Dashboard Layout
@@ -139,10 +139,19 @@ The use of an `iframe` may cause some spacing issues in the following demo.
 
 ## Customization
 
-Some areas of the layout can be replaced with custom components by using the `slots` and `slotProps` props.
-This allows you to add, for example:
+### Slots
 
-- new items to the toolbar in the header, such as a search bar or button;
-- footer content in the sidebar.
+Certain areas of the layout can be replaced with custom components by using the `slots` and `slotProps` props.
+Some possibly useful slots:
+
+- `toolbarActions`: allows you to add new items to the toolbar in the header, such as a search bar or button. The default `ThemeSwitcher` component can be imported and used if you wish to do so, as shown in the example below.
+
+- `sidebarFooter`: allows you to add footer content in the sidebar.
 
 {{"demo": "DashboardLayoutSlots.js", "height": 400, "iframe": true}}
+
+### Examples
+
+#### Settings menu with custom theme switcher
+
+{{"demo": "DashboardLayoutCustomThemeSwitcher.js", "height": 400, "iframe": true}}

--- a/docs/data/toolpad/core/pagesApi.js
+++ b/docs/data/toolpad/core/pagesApi.js
@@ -12,4 +12,6 @@ module.exports = [
   { pathname: '/toolpad/core/api/sign-in-button' },
   { pathname: '/toolpad/core/api/sign-in-page' },
   { pathname: '/toolpad/core/api/sign-out-button' },
+  { pathname: '/toolpad/core/api/theme-switcher' },
+  { pathname: '/toolpad/core/api/toolbar-actions' },
 ];

--- a/docs/pages/toolpad/core/api/theme-switcher.js
+++ b/docs/pages/toolpad/core/api/theme-switcher.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import ApiPage from 'docs/src/modules/components/ApiPage';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import jsonPageContent from './theme-switcher.json';
+
+export default function Page(props) {
+  const { descriptions, pageContent } = props;
+  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+}
+
+Page.getInitialProps = () => {
+  const req = require.context(
+    'docs-toolpad/translations/api-docs/theme-switcher',
+    false,
+    /\.\/theme-switcher.*.json$/,
+  );
+  const descriptions = mapApiPageTranslations(req);
+
+  return {
+    descriptions,
+    pageContent: jsonPageContent,
+  };
+};

--- a/docs/pages/toolpad/core/api/theme-switcher.json
+++ b/docs/pages/toolpad/core/api/theme-switcher.json
@@ -1,0 +1,11 @@
+{
+  "props": {},
+  "name": "ThemeSwitcher",
+  "imports": ["import { ThemeSwitcher } from '@toolpad/core/DashboardLayout';"],
+  "classes": [],
+  "muiName": "ThemeSwitcher",
+  "filename": "/packages/toolpad-core/src/DashboardLayout/ThemeSwitcher.tsx",
+  "inheritance": null,
+  "demos": "<ul><li><a href=\"/toolpad/core/react-dashboard-layout/\">Dashboard Layout</a></li></ul>",
+  "cssComponent": false
+}

--- a/docs/pages/toolpad/core/api/toolbar-actions.js
+++ b/docs/pages/toolpad/core/api/toolbar-actions.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import ApiPage from 'docs/src/modules/components/ApiPage';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import jsonPageContent from './toolbar-actions.json';
+
+export default function Page(props) {
+  const { descriptions, pageContent } = props;
+  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+}
+
+Page.getInitialProps = () => {
+  const req = require.context(
+    'docs-toolpad/translations/api-docs/toolbar-actions',
+    false,
+    /\.\/toolbar-actions.*.json$/,
+  );
+  const descriptions = mapApiPageTranslations(req);
+
+  return {
+    descriptions,
+    pageContent: jsonPageContent,
+  };
+};

--- a/docs/pages/toolpad/core/api/toolbar-actions.json
+++ b/docs/pages/toolpad/core/api/toolbar-actions.json
@@ -1,0 +1,11 @@
+{
+  "props": {},
+  "name": "ToolbarActions",
+  "imports": ["import { ToolbarActions } from '@toolpad/core/DashboardLayout';"],
+  "classes": [],
+  "muiName": "ToolbarActions",
+  "filename": "/packages/toolpad-core/src/DashboardLayout/ToolbarActions.tsx",
+  "inheritance": null,
+  "demos": "<ul><li><a href=\"/toolpad/core/react-dashboard-layout/\">Dashboard Layout</a></li></ul>",
+  "cssComponent": false
+}

--- a/docs/translations/api-docs/theme-switcher/theme-switcher.json
+++ b/docs/translations/api-docs/theme-switcher/theme-switcher.json
@@ -1,0 +1,1 @@
+{ "componentDescription": "", "propDescriptions": {}, "classDescriptions": {} }

--- a/docs/translations/api-docs/toolbar-actions/toolbar-actions.json
+++ b/docs/translations/api-docs/toolbar-actions/toolbar-actions.json
@@ -1,0 +1,1 @@
+{ "componentDescription": "", "propDescriptions": {}, "classDescriptions": {} }

--- a/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
@@ -20,7 +20,6 @@ import { Account, type AccountProps } from '../Account';
 import { useApplicationTitle } from '../shared/branding';
 import { DashboardSidebarSubNavigation } from './DashboardSidebarSubNavigation';
 import { ToolbarActions } from './ToolbarActions';
-import { ThemeSwitcher } from './ThemeSwitcher';
 import { ToolpadLogo } from './ToolpadLogo';
 import { getDrawerSxTransitionMixin, getDrawerWidthTransitionMixin } from './utils';
 
@@ -375,7 +374,6 @@ function DashboardLayout(props: DashboardLayoutProps) {
           <Box sx={{ flexGrow: 1 }} />
           <Stack direction="row" spacing={1}>
             <ToolbarActionsSlot {...slotProps?.toolbarActions} />
-            <ThemeSwitcher />
             <ToolbarAccountSlot {...slotProps?.toolbarAccount} />
           </Stack>
         </Toolbar>

--- a/packages/toolpad-core/src/DashboardLayout/ThemeSwitcher.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/ThemeSwitcher.tsx
@@ -7,10 +7,15 @@ import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import useSsr from '@toolpad/utils/hooks/useSsr';
 import { PaletteModeContext } from '../shared/context';
-
-// TODO: When we use this component as the default for a slot, make it non-internal
 /**
- * @ignore - internal component.
+ *
+ * Demos:
+ *
+ * - [Dashboard Layout](https://mui.com/toolpad/core/react-dashboard-layout/)
+ *
+ * API:
+ *
+ * - [ThemeSwitcher API](https://mui.com/toolpad/core/api/theme-switcher)
  */
 function ThemeSwitcher() {
   const isSsr = useSsr();

--- a/packages/toolpad-core/src/DashboardLayout/ToolbarActions.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/ToolbarActions.tsx
@@ -1,11 +1,23 @@
 'use client';
-
-// TODO: When we add content to this component, make it non-internal
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import { ThemeSwitcher } from './ThemeSwitcher';
 /**
- * @ignore - internal component.
+ *
+ * Demos:
+ *
+ * - [Dashboard Layout](https://mui.com/toolpad/core/react-dashboard-layout/)
+ *
+ * API:
+ *
+ * - [ToolbarActions API](https://mui.com/toolpad/core/api/toolbar-actions)
  */
 function ToolbarActions() {
-  return null;
+  return (
+    <Stack direction="row">
+      <ThemeSwitcher />
+    </Stack>
+  );
 }
 
 export { ToolbarActions };

--- a/packages/toolpad-core/src/DashboardLayout/index.ts
+++ b/packages/toolpad-core/src/DashboardLayout/index.ts
@@ -1,4 +1,3 @@
 export * from './DashboardLayout';
-
-// Default slots components
 export * from './ToolbarActions';
+export * from './ThemeSwitcher';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2124,7 +2124,7 @@ packages:
   '@docsearch/react@3.6.2':
     resolution: {integrity: sha512-rtZce46OOkVflCQH71IdbXSFK+S8iJZlUF56XBW5rIgx/eG5qoomC7Ag3anZson1bBac/JFQn7XOBfved/IMRA==}
     peerDependencies:
-      '@types/react': '>= 16.8.0 < 19.0.0'
+      '@types/react': ^18.3.11
       react: '>= 16.8.0 < 19.0.0'
       react-dom: '>= 16.8.0 < 19.0.0'
       search-insights: '>= 1 < 3'
@@ -4056,8 +4056,8 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0
-      '@types/react-dom': ^18.0.0
+      '@types/react': ^18.3.11
+      '@types/react-dom': 18.3.1
       react: ^18.0.0
       react-dom: ^18.0.0
     peerDependenciesMeta:


### PR DESCRIPTION
Closes https://github.com/mui/toolpad/issues/4151 and https://github.com/mui/toolpad/issues/4291

- Include `ThemeSwitcher` component in `toolbarActions` slot so it can be hidden
- Export existing `ThemeSwitcher` and `ToolbarActions` (default slot) components
- Add example of popover menu & custom theme switcher in `DashboardLayout` demo page in docs