### PR TITLE
[docs] Move the description to match the other pages

### DIFF
--- a/docs/data/toolpad/core/introduction/integration.md
+++ b/docs/data/toolpad/core/introduction/integration.md
@@ -1,11 +1,10 @@
 ---
 title: Toolpad Core - Integration
-description: How to integrate Toolpad Core into your existing project.
 ---
 
 # Integration
 
-This guide will walk you through the process of adding Toolpad Core to an existing project.
+<p class="descripton">This guide will walk you through the process of adding Toolpad Core to an existing project.</p>
 
 ## Installation
 

--- a/docs/data/toolpad/core/introduction/integration.md
+++ b/docs/data/toolpad/core/introduction/integration.md
@@ -4,7 +4,7 @@ title: Toolpad Core - Integration
 
 # Integration
 
-<p class="descripton">This guide will walk you through the process of adding Toolpad Core to an existing project.</p>
+<p class="description">This guide walks you through adding Toolpad Core to an existing project.</p>
 
 ## Installation
 


### PR DESCRIPTION
See https://mui.com/toolpad/core/introduction/integration/, it feels strange. Fixing #4080. I noticed this on #4344.

After: https://deploy-preview-4348--mui-toolpad-docs.netlify.app/toolpad/core/introduction/integration/