### PR TITLE
[docs] Fix missing ponctuation on descriptions

### DIFF
--- a/docs/data/toolpad/core/customization.md
+++ b/docs/data/toolpad/core/customization.md
@@ -1,3 +1,3 @@
 # Customization
 
-<p class="description">How to customize Toolpad Core</p>
+<p class="description">How to customize Toolpad Core.</p>

--- a/docs/data/toolpad/core/features/audit-logs.md
+++ b/docs/data/toolpad/core/features/audit-logs.md
@@ -1,3 +1,3 @@
 # Audit Logs
 
-<p class="description">Toolpad can provide access to internal events to be displayed on your dashboard as audit logs</p>
+<p class="description">Toolpad can provide access to internal events to be displayed on your dashboard as audit logs.</p>

--- a/docs/data/toolpad/core/features/authentication.md
+++ b/docs/data/toolpad/core/features/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-<p class="description">Toolpad provides working authentication out of the box, with support for multiple providers</p>
+<p class="description">Toolpad provides working authentication out of the box, with support for multiple providers.</p>
 
 ## Setup authentication pages
 


### PR DESCRIPTION
Make the next docs-infra upgrade easier for https://github.com/mui/material-ui/pull/44292.