### PR TITLE
CHORE: replace "Toolpad" default title with empty string

### DIFF
--- a/packages/toolpad-core/src/shared/branding.ts
+++ b/packages/toolpad-core/src/shared/branding.ts
@@ -3,5 +3,5 @@ import { BrandingContext } from './context';
 
 export function useApplicationTitle() {
   const branding = React.useContext(BrandingContext);
-  return branding?.title ?? 'Toolpad';
+  return branding?.title ?? '';
 }


### PR DESCRIPTION
As discussed in issue https://github.com/mui/toolpad/issues/4445, I replaced the default "Toolpad" title with an empty string.
