### PR TITLE
[docs] Update deployed template link

### DIFF
--- a/docs/src/modules/components/Examples/core-examples.ts
+++ b/docs/src/modules/components/Examples/core-examples.ts
@@ -88,12 +88,12 @@ export default function examples() {
       description:
         'This example shows you how to get started building a dashboard with Toolpad Core, Next.js app router, Auth.js and Material UI components in a customized theme',
       src: '/static/toolpad/docs/core/functional-dashboard.png',
-      href: 'https://deploy-preview-4415--mui-toolpad-docs.netlify.app/toolpad/core/templates/nextjs-dashboard',
+      href: 'https://mui-toolpad-docs.netlify.app/toolpad/core/templates/nextjs-dashboard',
       srcDark: '/static/toolpad/docs/core/functional-dashboard-dark.png',
       source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs-themed',
       featured: true,
       new: true,
-      codesandbox:
+      codeSandbox:
         'https://codesandbox.io/s/github/mui/toolpad/tree/master/examples/core/auth-nextjs-themed',
     },
   ];


### PR DESCRIPTION
- There is more work to do to get the `https://mui.com/...` link to work for the new dashboard template
- (Most likely: we need to update the `_redirects` file on the monorepo with specific rules for the template path)
- Till then we can direct users to the `https://mui-toolpad-docs.netlify.app` URL
- (The current experience sees them go to the deploy preview URL first and then get redirected to the above URL, which is not ideal)