### PR TITLE
[docs] Handle integration docs 404

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -51,6 +51,7 @@
 /toolpad/how-to-guides/* /toolpad/studio/how-to-guides/:splat 301
 /toolpad/reference/* /toolpad/studio/reference/:splat 301
 /toolpad/core/installation/ /toolpad/core/introduction/installation/ 301
+/toolpad/core/introduction/integration/ /toolpad/core/integrations/nextjs-approuter/ 301
 
 # Create separate namespace on https://mui.com
 / /toolpad/


### PR DESCRIPTION
https://deploy-preview-4475--mui-toolpad-docs.netlify.app/toolpad/core/introduction/integration/ gets redirected.

Fix a regression introduced in #4411