### PR TITLE
[docs] Add 'New' badge for examples

### DIFF
--- a/docs/data/toolpad/core/pages.ts
+++ b/docs/data/toolpad/core/pages.ts
@@ -27,6 +27,7 @@ const pages: MuiPage[] = [
       {
         pathname: '/toolpad/core/introduction/examples',
         title: 'Examples',
+        newFeature: true,
       },
       {
         pathname: '/toolpad/core/introduction/roadmap',

--- a/docs/src/components/landing/Examples.js
+++ b/docs/src/components/landing/Examples.js
@@ -71,7 +71,7 @@ function ContentCard({ icon, title, description, href }) {
         {description}
       </Typography>
       <Link href={href} variant="body" sx={{ mt: 0.5 }}>
-        View more
+        Visit tutorial
         <KeyboardArrowRightRounded fontSize="small" />
       </Link>
     </Box>
@@ -112,7 +112,7 @@ export default function Examples() {
             <ContentCard
               icon={<DashboardRoundedIcon fontSize="small" color="primary" />}
               title="Admin app"
-              description="This app shows you to get started with Toolpad Core and use basic layout and navigation features."
+              description="This app shows you how to get started with Toolpad Core and use basic layout and navigation features."
               href="https://mui.com/toolpad/core/introduction/tutorial/"
             />
           </Grid>
@@ -160,7 +160,7 @@ export default function Examples() {
                 Learn how to build these and many other apps using Toolpad Core!
               </Typography>
               <Link href="/toolpad/core/introduction/examples/" variant="body" sx={{ mt: 1 }}>
-                Check out docs
+                Explore more examples
                 <KeyboardArrowRightRounded fontSize="small" />
               </Link>
             </Box>


### PR DESCRIPTION
Preview: https://deploy-preview-4481--mui-toolpad-docs.netlify.app/toolpad/

Also, I was planning to replace the example on the marketing page with the new template. But didn't do it and instead changed the CTA copies. I think having the tutorial linked from there is better.