### PR TITLE
Micro-improvements concerning types

### DIFF
--- a/examples/core/vite/src/App.tsx
+++ b/examples/core/vite/src/App.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import { Outlet } from 'react-router-dom';
-import { AppProvider, type Navigation } from '@toolpad/core/react-router-dom';
+import { AppProvider } from '@toolpad/core/react-router-dom';
+import { type Navigation } from '@toolpad/core/AppProvider';
 
 const NAVIGATION: Navigation = [
   {
@@ -24,10 +25,12 @@ const BRANDING = {
   title: 'My Toolpad Core App',
 };
 
-export default function App() {
+const App: React.FC = () => {
   return (
     <AppProvider navigation={NAVIGATION} branding={BRANDING}>
       <Outlet />
     </AppProvider>
   );
 }
+
+export default App;


### PR DESCRIPTION
1. There is no `Navigation` type in `@toolpad/core/react-router-dom`. However, I found it in `@toolpad/core/AppProvider`;
2. Added explicit type `React.FC` for the `App` component (otherwise importing `* as React from 'react'` would be unnecessary).
