### PR TITLE
[core] Wrap App Router `AppProvider` in Suspense

### DIFF
--- a/docs/data/toolpad/core/integrations/nextjs-approuter.md
+++ b/docs/data/toolpad/core/integrations/nextjs-approuter.md
@@ -32,14 +32,17 @@ In your root layout file (for example, `app/layout.tsx`), wrap your application 
 
 ```tsx title="app/layout.tsx"
 import { AppProvider } from '@toolpad/core/AppProvider';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import LinearProgress from '@mui/material/LinearProgress';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <AppRouterCacheProvider options={{ enableCssLayer: true }}>
-      <AppProvider navigation={NAVIGATION} branding={BRANDING}>
-        {children}
-      </AppProvider>
+      <React.Suspense fallback={<LinearProgress />}>
+        <AppProvider navigation={NAVIGATION} branding={BRANDING}>
+          {children}
+        </AppProvider>
+      </React.Suspense>
     </AppRouterCacheProvider>
   );
 }
@@ -51,6 +54,10 @@ You can find details on the `AppProvider` props on the [AppProvider](/toolpad/co
 The `AppRouterCacheProvider` component is not required to use Toolpad Core, but it's recommended to use it to ensure that the styles are appended to the `<head>` and not rendering in the `<body>`.
 
 See the [Material UI Next.js integration docs](https://mui.com/material-ui/integrations/nextjs/) for more details.
+:::
+
+:::warning
+If your app is statically rendered, you must wrap the `AppProvider` in a `Suspense` component when using the app router. See [https://github.com/mui/toolpad/issues/4524](https://github.com/mui/toolpad/issues/4524) for more information.
 :::
 
 ## Create a dashboard layout

--- a/examples/core/auth-nextjs-email/src/app/layout.tsx
+++ b/examples/core/auth-nextjs-email/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppProvider } from '@toolpad/core/nextjs';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import type { Navigation } from '@toolpad/core';

--- a/examples/core/auth-nextjs-passkey/src/app/layout.tsx
+++ b/examples/core/auth-nextjs-passkey/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppProvider } from '@toolpad/core/nextjs';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import type { Navigation } from '@toolpad/core';

--- a/examples/core/auth-nextjs-themed/app/layout.tsx
+++ b/examples/core/auth-nextjs-themed/app/layout.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AppProvider } from '@toolpad/core/nextjs';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import type { Navigation } from '@toolpad/core/AppProvider';
 import { SessionProvider, signIn, signOut } from 'next-auth/react';
 import theme from '../theme';

--- a/examples/core/auth-nextjs/src/app/layout.tsx
+++ b/examples/core/auth-nextjs/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppProvider } from '@toolpad/core/nextjs';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import type { Navigation } from '@toolpad/core/AppProvider';

--- a/examples/core/tutorial/app/layout.tsx
+++ b/examples/core/tutorial/app/layout.tsx
@@ -1,8 +1,10 @@
+import * as React from 'react';
 import { AppProvider } from '@toolpad/core/nextjs';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import type { Navigation } from '@toolpad/core/AppProvider';
+import LinearProgress from '@mui/material/LinearProgress';
 import theme from '../theme';
 
 const NAVIGATION: Navigation = [
@@ -27,9 +29,11 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
     <html lang="en" data-toolpad-color-scheme="light">
       <body>
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
-          <AppProvider theme={theme} navigation={NAVIGATION}>
-            {children}
-          </AppProvider>
+          <React.Suspense fallback={<LinearProgress />}>
+            <AppProvider theme={theme} navigation={NAVIGATION}>
+              {children}
+            </AppProvider>
+          </React.Suspense>
         </AppRouterCacheProvider>
       </body>
     </html>

--- a/packages/create-toolpad-app/src/templates/nextjs-app/rootLayout.ts
+++ b/packages/create-toolpad-app/src/templates/nextjs-app/rootLayout.ts
@@ -5,9 +5,10 @@ const rootLayout: Template = (options) => {
 
   return `import * as React from 'react';
 import { AppProvider } from '@toolpad/core/nextjs';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+${authEnabled ? '' : `import LinearProgress from '@mui/material/LinearProgress'`}
 import type { Navigation } from '@toolpad/core/AppProvider';
 ${
   authEnabled
@@ -57,6 +58,7 @@ export default ${authEnabled ? 'async ' : ''}function RootLayout(props: { childr
       <body>
         ${authEnabled ? '<SessionProvider session={session}>' : ''}
           <AppRouterCacheProvider options={{ enableCssLayer: true }}>
+          ${authEnabled ? '' : '<React.Suspense fallback={<LinearProgress />}>'}
             <AppProvider
               navigation={NAVIGATION}
               branding={BRANDING}
@@ -70,6 +72,7 @@ export default ${authEnabled ? 'async ' : ''}function RootLayout(props: { childr
             >
               {props.children}
             </AppProvider>
+            ${authEnabled ? '' : '</React.Suspense>'}
           </AppRouterCacheProvider>
         ${authEnabled ? '</SessionProvider>' : ''}
       </body>

--- a/packages/toolpad-utils/src/react.tsx
+++ b/packages/toolpad-utils/src/react.tsx
@@ -10,7 +10,7 @@ export function interleave(items: React.ReactNode[], separator: React.ReactNode)
   for (let i = 0; i < items.length; i += 1) {
     if (i > 0) {
       if (ReactIs.isElement(separator)) {
-        result.push(React.cloneElement(separator, { key: `separator-${i}` }));
+        result.push(React.cloneElement(separator as React.ReactElement, { key: `separator-${i}` }));
       } else {
         result.push(separator);
       }

--- a/playground/nextjs/src/app/layout.tsx
+++ b/playground/nextjs/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppProvider } from '@toolpad/core/nextjs';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import type { Navigation } from '@toolpad/core/AppProvider';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,7 @@ importers:
         version: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-compiler:
         specifier: latest
-        version: 19.0.0-beta-df7b47d-20241124(eslint@8.57.1)
+        version: 19.0.0-beta-37ed2a7-20241206(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: 5.0.0
         version: 5.0.0(eslint@8.57.1)
@@ -1631,6 +1631,13 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
@@ -6057,8 +6064,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-react-compiler@19.0.0-beta-df7b47d-20241124:
-    resolution: {integrity: sha512-82PfnllC8jP/68KdLAbpWuYTcfmtGLzkqy2IW85WopKMTr+4rdQpp+lfliQ/QE79wWrv/dRoADrk3Pdhq25nTw==}
+  eslint-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206:
+    resolution: {integrity: sha512-5Pex1fUCJwLwwqEJe6NkgTn45kUjjj9TZP6IrW4IcpWM/YaEe+QvcOeF60huDjBq0kz1svGeW2nw8WdY+qszAw==}
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     peerDependencies:
       eslint: '>=7'
@@ -10910,6 +10917,14 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
+      '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15900,11 +15915,11 @@ snapshots:
       globals: 13.24.0
       rambda: 7.5.0
 
-  eslint-plugin-react-compiler@19.0.0-beta-df7b47d-20241124(eslint@8.57.1):
+  eslint-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206(eslint@8.57.1):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/parser': 7.26.2
-      '@babel/plugin-transform-private-methods': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.0)
       eslint: 8.57.1
       hermes-parser: 0.25.1
       zod: 3.23.8


### PR DESCRIPTION
- Fixes #4524 
- Statically rendered app builds fail with https://github.com/vercel/next.js/discussions/61654 without it
- Add a callout on the App Router integration docs
- Also update the `AppRouterCacheProvider` versions in examples