### PR TITLE
[SignInPage] Make control in rememberMe slot prop optional

### DIFF
--- a/packages/toolpad-core/src/SignInPage/SignInPage.tsx
+++ b/packages/toolpad-core/src/SignInPage/SignInPage.tsx
@@ -254,7 +254,7 @@ export interface SignInPageProps {
     submitButton?: LoadingButtonProps;
     forgotPasswordLink?: LinkProps;
     signUpLink?: LinkProps;
-    rememberMe?: FormControlLabelProps;
+    rememberMe?: Partial<FormControlLabelProps>;
   };
   /**
    * The prop used to customize the styles on the `SignInPage` container


### PR DESCRIPTION
The type for `rememberMe` slot prop in `SignInPage`  requires `control`, while control is provided in `SignInPage` by default so when you don't provide `control` typescript throws. This PR fixes this problem.