### PR TITLE
Do not make text bold in navigation sidebar

### DIFF
--- a/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
@@ -233,9 +233,6 @@ function DashboardSidebarSubNavigation({
                 sx={{
                   whiteSpace: 'nowrap',
                   zIndex: 1,
-                  '& .MuiTypography-root': {
-                    fontWeight: '500',
-                  },
                 }}
               />
               {navigationItem.action && !isMini && isFullyExpanded ? navigationItem.action : null}


### PR DESCRIPTION
In my last call with Olivier he did not expect the sidebar items in the layout to be slightly bold.
This simple change makes them the default font weight.

**Before:**

<img width="1358" alt="Screenshot 2024-12-11 at 14 05 55" src="https://github.com/user-attachments/assets/fb754b85-a140-45f1-8ba4-2f7ed5aef055" />

**After:**

<img width="1798" alt="Screenshot 2024-12-11 at 14 05 32" src="https://github.com/user-attachments/assets/31b9f16e-de8f-424d-b518-857079c3032c" />
