### PR TITLE
[docs] Improve callout copy for layout override props

### DIFF
--- a/docs/data/toolpad/core/components/dashboard-layout/dashboard-layout.md
+++ b/docs/data/toolpad/core/components/dashboard-layout/dashboard-layout.md
@@ -37,7 +37,8 @@ This can be done via the `branding` prop in the [AppProvider](https://mui.com/to
 {{"demo": "DashboardLayoutBranding.js", "height": 400, "iframe": true}}
 
 :::info
-Optionally, a specific `branding` can also be passed as a prop to the `DashboardLayout` component itself, which properties take precedence over any properties of the `branding` prop passed to the `AppProvider`.
+Optionally, you can also pass a specific `branding` object as a prop to the `DashboardLayout` component itself.
+When applied this way, the properties of this object take precedence over the properties of the `branding` prop passed to the `AppProvider`.
 
 You may also override the default branding by passing in your own component to the `appTitle` slot, as shown in the [Slots section](#slots).
 :::
@@ -49,7 +50,8 @@ The `navigation` prop in the [AppProvider](https://mui.com/toolpad/core/react-ap
 The flexibility in composing and ordering these different elements allows for a great variety of navigation structures to fit your use case.
 
 :::info
-Optionally, a specific `navigation` can also be passed as a prop to the `DashboardLayout` component itself, which takes complete precedence over any `navigation` prop passed to the `AppProvider`.
+Optionally, you can also pass a specific `navigation` as a prop to the `DashboardLayout` component itself.
+When applied this way, this `navigation` takes complete precedence over the `navigation` prop passed to the `AppProvider`.
 :::
 
 ### Navigation links


### PR DESCRIPTION
Improve copy as discussed in https://github.com/mui/toolpad/pull/4523