### PR TITLE
[internal] Remove duplicate eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,18 +56,22 @@ module.exports = {
    */
   rules: {
     ...baseline.rules,
-    // TODO move to @mui/monorepo, codebase is moving away from default exports https://github.com/mui/material-ui/issues/21862
+    /* TODO, trying to move to @mui/monorepo */
+    // codebase is moving away from default exports https://github.com/mui/material-ui/issues/21862
     'import/prefer-default-export': 'off',
-    'no-restricted-imports': ['error', noRestrictedImports],
+    'react-compiler/react-compiler': 'error',
+    // Turning react/jsx-key back on.
+    // https://github.com/airbnb/javascript/blob/5155aa5fc1ea9bb2c6493a06ddbd5c7a05414c86/packages/eslint-config-airbnb/rules/react.js#L94
+    'react/jsx-key': ['error', { checkKeyMustBeforeSpread: true, warnOnDuplicates: true }],
+
+    /* Toolpad specfic */
     'no-restricted-syntax': [
       ...baseline.rules['no-restricted-syntax'].filter((rule) => {
         // Too opinionated for Toolpad
         return rule?.selector !== 'ForOfStatement';
       }),
     ],
-    // Turning react/jsx-key back on.
-    // https://github.com/airbnb/javascript/blob/5155aa5fc1ea9bb2c6493a06ddbd5c7a05414c86/packages/eslint-config-airbnb/rules/react.js#L94
-    'react/jsx-key': ['error', { checkKeyMustBeforeSpread: true, warnOnDuplicates: true }],
+    'no-restricted-imports': ['error', noRestrictedImports],
     'import/no-unresolved': [
       'error',
       {
@@ -89,7 +93,6 @@ module.exports = {
       },
     ],
     'material-ui/no-hardcoded-labels': 'off', // We are not really translating the docs/website anymore
-    'react-compiler/react-compiler': 'error',
   },
   overrides: [
     ...baseline.overrides,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,29 +109,6 @@ module.exports = {
       extends: ['plugin:testing-library/react'],
     },
     {
-      files: ['docs/src/modules/components/**/*.js'],
-      rules: {
-        'material-ui/no-hardcoded-labels': 'off',
-      },
-    },
-    {
-      /**
-       * TODO move to @mui/monorepo
-       *
-       * Examples are for demostration purposes and should not be considered as part of the library.
-       * They don't contain an eslint setup, so we don't want them to contain eslint directives
-       * We do however want to keep the rules in place to ensure the examples are following
-       * a reasonably similar code style as the library.
-       */
-      files: ['examples/**/*'],
-      rules: {
-        'no-console': 'off',
-        'no-underscore-dangle': 'off',
-        // no node_modules in examples as they are not installed
-        'import/no-unresolved': 'off',
-      },
-    },
-    {
       files: [
         'packages/create-toolpad-app/**/*',
         'packages/toolpad-core/**/*',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,15 +68,6 @@ module.exports = {
     // Turning react/jsx-key back on.
     // https://github.com/airbnb/javascript/blob/5155aa5fc1ea9bb2c6493a06ddbd5c7a05414c86/packages/eslint-config-airbnb/rules/react.js#L94
     'react/jsx-key': ['error', { checkKeyMustBeforeSpread: true, warnOnDuplicates: true }],
-    // This got turned of in the mono-repo:
-    // See https://github.com/mui/toolpad/pull/866#discussion_r957222171
-    'react/no-unused-prop-types': [
-      'error',
-      {
-        customValidators: [],
-        skipShapeProps: true,
-      },
-    ],
     'import/no-unresolved': [
       'error',
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,8 +58,6 @@ module.exports = {
     ...baseline.rules,
     // TODO move to @mui/monorepo, codebase is moving away from default exports https://github.com/mui/material-ui/issues/21862
     'import/prefer-default-export': 'off',
-    // TODO move rule into the main repo once it has upgraded
-    '@typescript-eslint/return-await': 'off',
     'no-restricted-imports': ['error', noRestrictedImports],
     'no-restricted-syntax': [
       ...baseline.rules['no-restricted-syntax'].filter((rule) => {


### PR DESCRIPTION
Eslint rule already defined.

The fewer duplicated line of code this file has in Toolpad, the stronger the config in the main repo, the closest to success for the shared config file we are.

I noticed this with #4350.