### PR TITLE
[docs] Improve example README files

### DIFF
--- a/examples/core/auth-nextjs-email/README.md
+++ b/examples/core/auth-nextjs-email/README.md
@@ -50,6 +50,8 @@ To copy this example and customize it for your needs, run
 
 ```bash
 npx create-toolpad-app@latest --example auth-nextjs-email
+# or
+pnpm dlx create-toolpad-app@latest --example auth-nextjs-email
 ```
 
 and follow the instructions in the terminal.

--- a/examples/core/auth-nextjs-pages-nextauth-4/README.md
+++ b/examples/core/auth-nextjs-pages-nextauth-4/README.md
@@ -24,6 +24,8 @@ To copy this example and customize it for your needs, run
 
 ```bash
 npx create-toolpad-app@latest --example auth-nextjs-pages-nextauth-4
+# or
+pnpm dlx create-toolpad-app@latest --example auth-nextjs-pages-nextauth-4
 ```
 
 and follow the instructions in the terminal.

--- a/examples/core/auth-nextjs-pages/README.md
+++ b/examples/core/auth-nextjs-pages/README.md
@@ -46,6 +46,8 @@ To copy this example and customize it for your needs, run
 
 ```bash
 npx create-toolpad-app@latest --example auth-nextjs-pages
+# or
+pnpm dlx create-toolpad-app@latest --example auth-nextjs-pages
 ```
 
 and follow the instructions in the terminal.

--- a/examples/core/auth-nextjs-passkey/README.md
+++ b/examples/core/auth-nextjs-passkey/README.md
@@ -40,6 +40,8 @@ To copy this example and customize it for your needs, run
 
 ```bash
 npx create-toolpad-app@latest --example auth-nextjs-passkey
+# or
+pnpm dlx create-toolpad-app@latest --example auth-nextjs-passkey
 ```
 
 and follow the instructions in the terminal.

--- a/examples/core/auth-nextjs-themed/README.md
+++ b/examples/core/auth-nextjs-themed/README.md
@@ -24,6 +24,8 @@ To copy this example and customize it for your needs, run
 
 ```bash
 npx create-toolpad-app@latest --example auth-nextjs-themed
+# or
+pnpm dlx create-toolpad-app@latest --example auth-nextjs-themed
 ```
 
 and follow the instructions in the terminal.

--- a/examples/core/auth-nextjs/README.md
+++ b/examples/core/auth-nextjs/README.md
@@ -34,6 +34,8 @@ GITHUB_CLIENT_SECRET=
 
 ```bash
 npx auth secret
+# or
+pnpm dlx create-toolpad-app@latest --example auth-nextjs
 ```
 
 ### GitHub configuration

--- a/examples/core/auth-vite/README.md
+++ b/examples/core/auth-vite/README.md
@@ -2,6 +2,16 @@
 
 This template provides a minimal setup to get React working in Vite with HMR.
 
+## Clone using `create-toolpad-app`
+
+To copy this example and customize it for your needs, run
+
+```bash
+npx create-toolpad-app@latest --example auth-vite
+# or
+pnpm dlx create-toolpad-app@latest --example auth-vite
+```
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/examples/core/firebase-vite/README.md
+++ b/examples/core/firebase-vite/README.md
@@ -2,6 +2,29 @@
 
 This template provides a minimal setup to get React working in Vite with HMR, and authentication with Firebase.
 
+## Setting up
+
+The project requires a `.env` with the following variables:
+
+```bash
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGE_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+```
+
+## Clone using `create-toolpad-app`
+
+To copy this example and customize it for your needs, run
+
+```bash
+npx create-toolpad-app@latest --example firebase-vite
+# or
+pnpm dlx create-toolpad-app@latest --example firebase-vite
+```
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/examples/core/tutorial/README.md
+++ b/examples/core/tutorial/README.md
@@ -1,6 +1,6 @@
-# Toolpad Core - Vite with React Router
+# Toolpad Core - Tutorial
 
-This example provides a minimal setup to get Toolpad Core working in Vite with HMR, as well as routing with React Router.
+This example provides a minimal setup to get Toolpad Core working with the Next.js app router.
 
 ## Getting Started
 
@@ -23,13 +23,13 @@ Open [http://localhost:5173](http://localhost:5173) with your browser to see the
 To copy this example and customize it for your needs, run
 
 ```bash
-npx create-toolpad-app@latest --example vite
+npx create-toolpad-app@latest --example tutorial
 # or
-pnpm dlx create-toolpad-app@latest --example vite
+pnpm dlx create-toolpad-app@latest --example tutorial
 ```
 
 and follow the instructions in the terminal.
 
 ## The source
 
-[Check out the source code](https://github.com/mui/toolpad/tree/master/examples/core/vite/)
+[Check out the source code](https://github.com/mui/toolpad/tree/master/examples/core/tutorial/)

--- a/examples/core/tutorial/README.md
+++ b/examples/core/tutorial/README.md
@@ -1,6 +1,6 @@
 # Toolpad Core - Tutorial
 
-This example provides a minimal setup to get Toolpad Core working with the Next.js app router.
+This example provides a minimal setup to get Toolpad Core working with the Next.js App Router.
 
 ## Getting Started
 


### PR DESCRIPTION
- Add clone with `create-toolpad-app` instruction to all README.md files for better discoverability