### PR TITLE
Use precise version in examples to try to fix CodeSandbox

### DIFF
--- a/examples/core/auth-nextjs-email/package.json
+++ b/examples/core/auth-nextjs-email/package.json
@@ -12,7 +12,7 @@
     "@mui/icons-material": "^6",
     "@mui/material": "^6",
     "@mui/material-nextjs": "^6",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "@prisma/client": "^5",
     "@auth/prisma-adapter": "^2",
     "next": "^15",

--- a/examples/core/auth-nextjs-pages-nextauth-4/package.json
+++ b/examples/core/auth-nextjs-pages-nextauth-4/package.json
@@ -13,7 +13,7 @@
     "@mui/icons-material": "^6",
     "@mui/material": "^6",
     "@mui/material-nextjs": "^6",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "next": "^15",
     "next-auth": "^4.24.10",
     "react": "^19.0.0",

--- a/examples/core/auth-nextjs-pages/package.json
+++ b/examples/core/auth-nextjs-pages/package.json
@@ -13,7 +13,7 @@
     "@mui/icons-material": "^6",
     "@mui/material": "^6",
     "@mui/material-nextjs": "^6",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "next": "^15",
     "next-auth": "5.0.0-beta.25",
     "react": "^19.0.0",

--- a/examples/core/auth-nextjs-passkey/package.json
+++ b/examples/core/auth-nextjs-passkey/package.json
@@ -15,7 +15,7 @@
     "@prisma/client": "^5",
     "@simplewebauthn/browser": "^9",
     "@simplewebauthn/server": "^9",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "next": "^15",
     "next-auth": "5.0.0-beta.25",
     "react": "^19.0.0",

--- a/examples/core/auth-nextjs-themed/package.json
+++ b/examples/core/auth-nextjs-themed/package.json
@@ -20,7 +20,7 @@
     "dayjs": "^1",
     "clsx": "^2",
     "@react-spring/web": "^9",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "next": "^15",
     "next-auth": "^5.0.0-beta.25",
     "react": "^19.0.0",

--- a/examples/core/auth-nextjs/package.json
+++ b/examples/core/auth-nextjs/package.json
@@ -11,7 +11,7 @@
     "@mui/icons-material": "^6",
     "@mui/material": "^6",
     "@mui/material-nextjs": "^6",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "next": "^15",
     "next-auth": "5.0.0-beta.25",
     "react": "^19.0.0",

--- a/examples/core/auth-vite/package.json
+++ b/examples/core/auth-vite/package.json
@@ -12,7 +12,7 @@
     "@emotion/styled": "^11",
     "@mui/icons-material": "^6",
     "@mui/material": "^6",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7"

--- a/examples/core/firebase-vite/package.json
+++ b/examples/core/firebase-vite/package.json
@@ -12,7 +12,7 @@
     "@emotion/styled": "^11",
     "@mui/icons-material": "^6",
     "@mui/material": "^6",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7"

--- a/examples/core/tutorial/package.json
+++ b/examples/core/tutorial/package.json
@@ -11,7 +11,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "next": "^15",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "@mui/material": "^6",
     "@mui/material-nextjs": "^6",
     "@mui/icons-material": "^6",

--- a/examples/core/vite/package.json
+++ b/examples/core/vite/package.json
@@ -12,7 +12,7 @@
     "@emotion/styled": "^11",
     "@mui/icons-material": "^6",
     "@mui/material": "^6",
-    "@toolpad/core": "latest",
+    "@toolpad/core": "^0.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7"


### PR DESCRIPTION
Attempt to fix CodeSandbox example errors in https://mui.com/toolpad/core/introduction/examples/ by using a more precise version in all examples, instead of `latest`.
The CodeSandbox example dependencies seem to be stuck in an old version for some reason.