### PR TITLE
[SignInPage] Add Non-Null Assertion to Prevent Compiler Errors

### DIFF
--- a/packages/toolpad-core/src/SignInPage/SignInPage.tsx
+++ b/packages/toolpad-core/src/SignInPage/SignInPage.tsx
@@ -40,7 +40,7 @@ import { BrandingContext, RouterContext } from '../shared/context';
 
 const mergeSlotSx = (defaultSx: SxProps<Theme>, slotProps?: { sx?: SxProps<Theme> }) => {
   if (Array.isArray(slotProps?.sx)) {
-    return [defaultSx, ...slotProps.sx];
+    return [defaultSx, ...slotProps!.sx];
   }
 
   if (slotProps?.sx) {


### PR DESCRIPTION
Sometimes, the TypeScript compiler raises an error about ‘slotProps’ possibly being undefined, even though it is guaranteed to be defined under the given condition.

```
Failed to compile.

TS18048: 'slotProps' is possibly 'undefined'.
    34 | const mergeSlotSx = (defaultSx: SxProps<Theme>, slotProps?: { sx?: SxProps<Theme> }) => {
    35 |   if (Array.isArray(slotProps?.sx)) {
  > 36 |     return [defaultSx, ...slotProps.sx];
       |                           ^^^^^^^^^
    37 |   }
    38 |
    39 |   if (slotProps?.sx) {

```

To resolve this, I added a non-null assertion to ensure the compiler no longer raises this unnecessary error.