### PR TITLE
[core] Page should have h1

### DIFF
--- a/packages/toolpad-core/src/SignInPage/SignInPage.tsx
+++ b/packages/toolpad-core/src/SignInPage/SignInPage.tsx
@@ -332,6 +332,7 @@ function SignInPage(props: SignInPageProps) {
           ) : (
             <Typography
               variant="h5"
+              component="h1"
               color="textPrimary"
               sx={{
                 my: theme.spacing(1),


### PR DESCRIPTION
<img width="546" alt="SCR-20250129-ryqe" src="https://github.com/user-attachments/assets/d6e9a308-aea7-49a1-8da6-5b0bc0b5aa8f" />

https://mui.com/toolpad/core/templates/nextjs-dashboard/auth/signin?callbackUrl=https%3A%2F%2Fmui.com%2Ftoolpad%2Fcore%2Ftemplates%2Fnextjs-dashboard

I was looking at the crawl reports https://app.ahrefs.com/site-audit/3833384/issues?current=29-01-2025T022904