### PR TITLE
[docs] Fix redirection to GitHub example view

### DIFF
--- a/docs/src/modules/components/examples/ExamplesFeatured.tsx
+++ b/docs/src/modules/components/examples/ExamplesFeatured.tsx
@@ -51,7 +51,7 @@ export default function ExamplesFeatured(props: FeaturedExamplesProps) {
               }}
             >
               <Link
-                href={versionGitHubLink(example.href)}
+                href={example.href}
                 target="_blank"
                 sx={{
                   position: 'relative',
@@ -162,7 +162,7 @@ export default function ExamplesFeatured(props: FeaturedExamplesProps) {
                 </Box>
                 <Button
                   component="a"
-                  href={versionGitHubLink(example.href)}
+                  href={example.href}
                   size="small"
                   variant="outlined"
                   color="primary"

--- a/docs/src/modules/components/examples/ExamplesGrid.tsx
+++ b/docs/src/modules/components/examples/ExamplesGrid.tsx
@@ -70,7 +70,7 @@ export default function ExamplesGrid(props: ExamplesGridProps) {
                 component="a"
                 image={computedSrc}
                 title={example.description}
-                href={versionGitHubLink(example.href || example.source)}
+                href={example.href || versionGitHubLink(example.source)}
                 rel="nofollow"
                 sx={(theme) => ({
                   height: 0,

--- a/docs/src/modules/components/examples/coreExamples.ts
+++ b/docs/src/modules/components/examples/coreExamples.ts
@@ -42,7 +42,7 @@ const coreExamples = [
       'This app shows you to how to get started using Toolpad Core with Auth.js Passkeys and the Next.js App Router.',
     src: '/static/toolpad/docs/core/auth-next-passkey.png',
     srcDark: '/static/toolpad/docs/core/auth-next-passkey-dark.png',
-    source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs-passkey/',
+    source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs-passkey',
     // Crash with Prisma
     codeSandbox: false,
     stackBlitz: false,
@@ -53,8 +53,7 @@ const coreExamples = [
       'This app shows you to how to get started using Toolpad Core with Auth.js v4 and the Next.js Pages router.',
     src: '/static/toolpad/docs/core/auth-next.png',
     srcDark: '/static/toolpad/docs/core/auth-next-dark.png',
-    source:
-      'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs-pages-nextauth-4/',
+    source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs-pages-nextauth-4',
     codeSandbox: true,
     // Show nothing
     stackBlitz: false,
@@ -65,7 +64,7 @@ const coreExamples = [
       'This app shows you to how to get started using Toolpad Core with Vite and React Router.',
     src: '/static/toolpad/docs/core/vite-react-router.png',
     srcDark: '/static/toolpad/docs/core/vite-react-router.png', // TODO Fix
-    source: 'https://github.com/mui/toolpad/tree/master/examples/core/vite/',
+    source: 'https://github.com/mui/toolpad/tree/master/examples/core/vite',
     codeSandbox: true,
     // Show nothing
     stackBlitz: false,
@@ -87,7 +86,7 @@ const coreExamples = [
       'This app shows you to how to get started using Toolpad Core with Auth.js and the Next.js Pages router.',
     src: '/static/toolpad/docs/core/auth-next.png',
     srcDark: '/static/toolpad/docs/core/auth-next-dark.png',
-    source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs-pages/',
+    source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs-pages',
     // infinite redirection
     codeSandbox: false,
     stackBlitz: false,
@@ -98,7 +97,7 @@ const coreExamples = [
       'This app shows you to how to get started using Toolpad Core with Auth.js and the Next.js App Router.',
     src: '/static/toolpad/docs/core/auth-next.png',
     srcDark: '/static/toolpad/docs/core/auth-next-dark.png',
-    source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs/',
+    source: 'https://github.com/mui/toolpad/tree/master/examples/core/auth-nextjs',
     codeSandbox: true,
     stackBlitz: true,
   },
@@ -109,7 +108,7 @@ const coreExamples = [
     src: '/static/toolpad/docs/core/tutorial-1.png',
     srcDark: '/static/toolpad/docs/core/tutorial-1.png', // TODO Fix
     href: 'https://mui.com/toolpad/core/introduction/tutorial/',
-    source: 'https://github.com/mui/toolpad/tree/master/examples/core/tutorial/',
+    source: 'https://github.com/mui/toolpad/tree/master/examples/core/tutorial',
     codeSandbox: true,
     stackBlitz: true,
   },

--- a/docs/src/modules/components/examples/examplesUtils.ts
+++ b/docs/src/modules/components/examples/examplesUtils.ts
@@ -13,7 +13,7 @@ export function versionGitHubLink(href: string) {
 
   return href.replace(
     `${process.env.SOURCE_CODE_REPO}/tree/master`,
-    `${process.env.SOURCE_CODE_REPO}/blob/v${process.env.LIB_VERSION}`,
+    `${process.env.SOURCE_CODE_REPO}/tree/v${process.env.LIB_VERSION}`,
   );
 }
 


### PR DESCRIPTION
#4350 was a bit too rushed. This creates a ton of 301 in the ahrefs crawls: https://app.ahrefs.com/site-audit/3833384/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CcontentType%2Cdepth%2Credirect%2CincomingAllLinks&current=29-01-2025T022904&filterId=b3b75b6257a370fcf9f1f73befb5deb5&issueId=c64d8847-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating
