### PR TITLE
Fix Next.js Pages Router pathname in AppProvider

### DIFF
--- a/packages/toolpad-core/src/DashboardLayout/DashboardLayout.test.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardLayout.test.tsx
@@ -260,15 +260,6 @@ describe('DashboardLayout', () => {
       'Mui-selected',
     );
 
-    rerender(<AppWithPathname pathname="/orders?query=test" />);
-
-    expect(within(desktopNavigation).getByRole('link', { name: 'Dashboard' })).not.toHaveClass(
-      'Mui-selected',
-    );
-    expect(within(desktopNavigation).getByRole('link', { name: 'Orders' })).toHaveClass(
-      'Mui-selected',
-    );
-
     rerender(<AppWithPathname pathname="/dynamic" />);
     expect(within(desktopNavigation).getByRole('link', { name: 'Dynamic' })).not.toHaveClass(
       'Mui-selected',

--- a/packages/toolpad-core/src/DashboardLayout/DashboardLayout.test.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardLayout.test.tsx
@@ -260,6 +260,15 @@ describe('DashboardLayout', () => {
       'Mui-selected',
     );
 
+    rerender(<AppWithPathname pathname="/orders?query=test" />);
+
+    expect(within(desktopNavigation).getByRole('link', { name: 'Dashboard' })).not.toHaveClass(
+      'Mui-selected',
+    );
+    expect(within(desktopNavigation).getByRole('link', { name: 'Orders' })).toHaveClass(
+      'Mui-selected',
+    );
+
     rerender(<AppWithPathname pathname="/dynamic" />);
     expect(within(desktopNavigation).getByRole('link', { name: 'Dynamic' })).not.toHaveClass(
       'Mui-selected',

--- a/packages/toolpad-core/src/nextjs/NextAppProviderPages.tsx
+++ b/packages/toolpad-core/src/nextjs/NextAppProviderPages.tsx
@@ -8,7 +8,7 @@ import type { AppProviderProps, Navigate, Router } from '../AppProvider';
  * @ignore - internal component.
  */
 export function NextAppProviderPages(props: AppProviderProps) {
-  const { push, replace, asPath, query } = useRouter();
+  const { push, replace, pathname, query } = useRouter();
 
   const search = React.useMemo(() => {
     const params = new URLSearchParams();
@@ -38,11 +38,11 @@ export function NextAppProviderPages(props: AppProviderProps) {
 
   const routerImpl = React.useMemo<Router>(
     () => ({
-      pathname: asPath,
+      pathname,
       searchParams,
       navigate,
     }),
-    [asPath, navigate, searchParams],
+    [navigate, pathname, searchParams],
   );
 
   return <AppProvider router={routerImpl} {...props} />;

--- a/playground/nextjs-pages/next-env.d.ts
+++ b/playground/nextjs-pages/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/playground/nextjs/next-env.d.ts
+++ b/playground/nextjs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Use `pathname` in Next.js Pages Router adapter.

Closes https://github.com/mui/toolpad/issues/4645#issuecomment-2631343237