### PR TITLE
[feat] Add `form` and `oauthButton` slot props

### DIFF
--- a/docs/data/toolpad/core/components/sign-in-page/BrandingSignInPage.js
+++ b/docs/data/toolpad/core/components/sign-in-page/BrandingSignInPage.js
@@ -35,7 +35,7 @@ export default function BrandingSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/BrandingSignInPage.tsx
+++ b/docs/data/toolpad/core/components/sign-in-page/BrandingSignInPage.tsx
@@ -35,7 +35,7 @@ export default function BrandingSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/BrandingSignInPage.tsx.preview
+++ b/docs/data/toolpad/core/components/sign-in-page/BrandingSignInPage.tsx.preview
@@ -15,6 +15,6 @@ const BRANDING = {
   <SignInPage
     signIn={signIn}
     providers={providers}
-    slotProps={{ emailField: { autoFocus: false } }}
+    slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
   />
 </AppProvider>

--- a/docs/data/toolpad/core/components/sign-in-page/CredentialsSignInPage.js
+++ b/docs/data/toolpad/core/components/sign-in-page/CredentialsSignInPage.js
@@ -27,7 +27,7 @@ export default function CredentialsSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/CredentialsSignInPage.tsx
+++ b/docs/data/toolpad/core/components/sign-in-page/CredentialsSignInPage.tsx
@@ -30,7 +30,7 @@ export default function CredentialsSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/CredentialsSignInPage.tsx.preview
+++ b/docs/data/toolpad/core/components/sign-in-page/CredentialsSignInPage.tsx.preview
@@ -6,6 +6,6 @@ const providers = [{ id: 'credentials', name: 'Email and Password' }];
   <SignInPage
     signIn={signIn}
     providers={providers}
-    slotProps={{ emailField: { autoFocus: false } }}
+    slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
   />
 </AppProvider>

--- a/docs/data/toolpad/core/components/sign-in-page/MagicLinkAlertSignInPage.js
+++ b/docs/data/toolpad/core/components/sign-in-page/MagicLinkAlertSignInPage.js
@@ -27,7 +27,7 @@ export default function MagicLinkAlertSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/MagicLinkAlertSignInPage.tsx
+++ b/docs/data/toolpad/core/components/sign-in-page/MagicLinkAlertSignInPage.tsx
@@ -36,7 +36,7 @@ export default function MagicLinkAlertSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/MagicLinkAlertSignInPage.tsx.preview
+++ b/docs/data/toolpad/core/components/sign-in-page/MagicLinkAlertSignInPage.tsx.preview
@@ -8,6 +8,6 @@ resolve({
   <SignInPage
     signIn={signIn}
     providers={providers}
-    slotProps={{ emailField: { autoFocus: false } }}
+    slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
   />
 </AppProvider>

--- a/docs/data/toolpad/core/components/sign-in-page/NotificationsSignInPageError.js
+++ b/docs/data/toolpad/core/components/sign-in-page/NotificationsSignInPageError.js
@@ -32,7 +32,7 @@ export default function NotificationsSignInPageError() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/NotificationsSignInPageError.tsx
+++ b/docs/data/toolpad/core/components/sign-in-page/NotificationsSignInPageError.tsx
@@ -39,7 +39,7 @@ export default function NotificationsSignInPageError() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/NotificationsSignInPageError.tsx.preview
+++ b/docs/data/toolpad/core/components/sign-in-page/NotificationsSignInPageError.tsx.preview
@@ -9,6 +9,6 @@ resolve({
   <SignInPage
     signIn={signIn}
     providers={providers}
-    slotProps={{ emailField: { autoFocus: false } }}
+    slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
   />
 </AppProvider>

--- a/docs/data/toolpad/core/components/sign-in-page/PasskeySignInPage.js
+++ b/docs/data/toolpad/core/components/sign-in-page/PasskeySignInPage.js
@@ -24,7 +24,7 @@ export default function PasskeySignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/PasskeySignInPage.tsx
+++ b/docs/data/toolpad/core/components/sign-in-page/PasskeySignInPage.tsx
@@ -24,7 +24,7 @@ export default function PasskeySignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
-        slotProps={{ emailField: { autoFocus: false } }}
+        slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
       />
     </AppProvider>
     // preview-end

--- a/docs/data/toolpad/core/components/sign-in-page/PasskeySignInPage.tsx.preview
+++ b/docs/data/toolpad/core/components/sign-in-page/PasskeySignInPage.tsx.preview
@@ -6,6 +6,6 @@ const providers = [{ id: 'passkey', name: 'Passkey' }];
   <SignInPage
     signIn={signIn}
     providers={providers}
-    slotProps={{ emailField: { autoFocus: false } }}
+    slotProps={{ emailField: { autoFocus: false }, form: { noValidate: true } }}
   />
 </AppProvider>

--- a/docs/data/toolpad/core/components/sign-in-page/ThemeSignInPage.js
+++ b/docs/data/toolpad/core/components/sign-in-page/ThemeSignInPage.js
@@ -44,6 +44,7 @@ export default function ThemeSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
+        slotProps={{ form: { noValidate: true } }}
         sx={{
           '& form > .MuiStack-root': {
             marginTop: '2rem',

--- a/docs/data/toolpad/core/components/sign-in-page/ThemeSignInPage.tsx
+++ b/docs/data/toolpad/core/components/sign-in-page/ThemeSignInPage.tsx
@@ -50,6 +50,7 @@ export default function ThemeSignInPage() {
       <SignInPage
         signIn={signIn}
         providers={providers}
+        slotProps={{ form: { noValidate: true } }}
         sx={{
           '& form > .MuiStack-root': {
             marginTop: '2rem',

--- a/docs/data/toolpad/core/components/sign-in-page/ThemeSignInPage.tsx.preview
+++ b/docs/data/toolpad/core/components/sign-in-page/ThemeSignInPage.tsx.preview
@@ -15,6 +15,7 @@ const THEME = createTheme({
   <SignInPage
     signIn={signIn}
     providers={providers}
+    slotProps={{ form: { noValidate: true } }}
     sx={{
       '& form > .MuiStack-root': {
         marginTop: '2rem',

--- a/docs/pages/toolpad/core/api/sign-in-page.json
+++ b/docs/pages/toolpad/core/api/sign-in-page.json
@@ -15,7 +15,7 @@
     "slotProps": {
       "type": {
         "name": "shape",
-        "description": "{ emailField?: object, forgotPasswordLink?: object, passwordField?: object, rememberMe?: object, signUpLink?: object, submitButton?: object }"
+        "description": "{ emailField?: object, forgotPasswordLink?: object, form?: object, oAuthButton?: object, passwordField?: object, rememberMe?: object, signUpLink?: object, submitButton?: object }"
       },
       "default": "{}"
     },

--- a/packages/toolpad-core/src/SignInPage/SignInPage.tsx
+++ b/packages/toolpad-core/src/SignInPage/SignInPage.tsx
@@ -718,6 +718,8 @@ SignInPage.propTypes /* remove-proptypes */ = {
   slotProps: PropTypes.shape({
     emailField: PropTypes.object,
     forgotPasswordLink: PropTypes.object,
+    form: PropTypes.object,
+    oAuthButton: PropTypes.object,
     passwordField: PropTypes.object,
     rememberMe: PropTypes.object,
     signUpLink: PropTypes.object,

--- a/packages/toolpad-core/src/SignInPage/SignInPage.tsx
+++ b/packages/toolpad-core/src/SignInPage/SignInPage.tsx
@@ -255,6 +255,8 @@ export interface SignInPageProps {
     forgotPasswordLink?: LinkProps;
     signUpLink?: LinkProps;
     rememberMe?: Partial<FormControlLabelProps>;
+    form?: Partial<React.FormHTMLAttributes<HTMLFormElement>>;
+    oAuthButton?: LoadingButtonProps;
   };
   /**
    * The prop used to customize the styles on the `SignInPage` container
@@ -375,6 +377,7 @@ function SignInPage(props: SignInPageProps) {
                           error: oauthResponse?.error,
                         }));
                       }}
+                      {...slotProps?.form}
                     >
                       <LoadingButton
                         key={provider.id}
@@ -391,6 +394,7 @@ function SignInPage(props: SignInPageProps) {
                         sx={{
                           textTransform: 'capitalize',
                         }}
+                        {...slotProps?.oAuthButton}
                       >
                         <span>Sign in with {provider.name}</span>
                       </LoadingButton>
@@ -424,6 +428,7 @@ function SignInPage(props: SignInPageProps) {
                       error: passkeyResponse?.error,
                     }));
                   }}
+                  {...slotProps?.form}
                 >
                   {slots?.emailField ? (
                     <slots.emailField {...slotProps?.emailField} />
@@ -498,6 +503,7 @@ function SignInPage(props: SignInPageProps) {
                       success: emailResponse?.success,
                     }));
                   }}
+                  {...slotProps?.form}
                 >
                   {slots?.emailField ? (
                     <slots.emailField {...slotProps?.emailField} />
@@ -570,6 +576,7 @@ function SignInPage(props: SignInPageProps) {
                       error: credentialsResponse?.error,
                     }));
                   }}
+                  {...slotProps?.form}
                 >
                   <Stack direction="column" spacing={2} sx={{ mb: 2 }}>
                     {slots?.emailField ? (


### PR DESCRIPTION
### Other Changes

- Add new `slotProps`:
   - `oauthButton`
   - `form` 
 
- Closes #4584 

- Move non-breaking changes out from https://github.com/mui/toolpad/pull/4574