### PR TITLE
Fix dialogs close

### DIFF
--- a/packages/toolpad-core/src/useDialogs/DialogsProvider.tsx
+++ b/packages/toolpad-core/src/useDialogs/DialogsProvider.tsx
@@ -38,60 +38,56 @@ function DialogsProvider(props: DialogProviderProps) {
   const keyPrefix = React.useId();
   const nextId = React.useRef(0);
 
-  const requestDialog = useEventCallback<OpenDialog>(
-    function open<P, R>(
-      Component: DialogComponent<P, R>,
-      payload: P,
-      options: OpenDialogOptions<R> = {},
-    ) {
-      const { onClose = async () => {} } = options;
-      let resolve: ((result: R) => void) | undefined;
-      const promise = new Promise<R>((resolveImpl) => {
-        resolve = resolveImpl;
-      });
-      invariant(resolve, 'resolve not set');
+  const requestDialog = useEventCallback<OpenDialog>(function open<P, R>(
+    Component: DialogComponent<P, R>,
+    payload: P,
+    options: OpenDialogOptions<R> = {},
+  ) {
+    const { onClose = async () => {} } = options;
+    let resolve: ((result: R) => void) | undefined;
+    const promise = new Promise<R>((resolveImpl) => {
+      resolve = resolveImpl;
+    });
+    invariant(resolve, 'resolve not set');
 
-      const key = `${keyPrefix}-${nextId.current}`;
-      nextId.current += 1;
+    const key = `${keyPrefix}-${nextId.current}`;
+    nextId.current += 1;
 
-      const newEntry: DialogStackEntry<P, R> = {
-        key,
-        open: true,
-        promise,
-        Component,
-        payload,
-        onClose,
-        resolve,
-      };
+    const newEntry: DialogStackEntry<P, R> = {
+      key,
+      open: true,
+      promise,
+      Component,
+      payload,
+      onClose,
+      resolve,
+    };
 
-      setStack((prevStack) => [...prevStack, newEntry]);
-      return promise;
-    }
-  );
+    setStack((prevStack) => [...prevStack, newEntry]);
+    return promise;
+  });
 
-  const closeDialogUi = useEventCallback(
-    function closeDialogUi<R>(dialog: Promise<R>) {
-      setStack((prevStack) =>
-        prevStack.map((entry) => (entry.promise === dialog ? { ...entry, open: false } : entry)),
-      );
-      setTimeout(() => {
-        // wait for closing animation
-        setStack((prevStack) => prevStack.filter((entry) => entry.promise !== dialog));
-      }, unmountAfter);
-    }
-  );
+  const closeDialogUi = useEventCallback(function closeDialogUi<R>(dialog: Promise<R>) {
+    setStack((prevStack) =>
+      prevStack.map((entry) => (entry.promise === dialog ? { ...entry, open: false } : entry)),
+    );
+    setTimeout(() => {
+      // wait for closing animation
+      setStack((prevStack) => prevStack.filter((entry) => entry.promise !== dialog));
+    }, unmountAfter);
+  });
 
-
-  const closeDialog = useEventCallback(
-    async function closeDialog<R>(dialog: Promise<R>, result: R) {
-      const entryToClose = stack.find((entry) => entry.promise === dialog);
-      invariant(entryToClose, 'dialog not found');
-      await entryToClose.onClose(result);
-      entryToClose.resolve(result);
-      closeDialogUi(dialog);
-      return dialog;
-    },
-  );
+  const closeDialog = useEventCallback(async function closeDialog<R>(
+    dialog: Promise<R>,
+    result: R,
+  ) {
+    const entryToClose = stack.find((entry) => entry.promise === dialog);
+    invariant(entryToClose, 'dialog not found');
+    await entryToClose.onClose(result);
+    entryToClose.resolve(result);
+    closeDialogUi(dialog);
+    return dialog;
+  });
 
   const contextValue = React.useMemo(
     () => ({ open: requestDialog, close: closeDialog }),

--- a/packages/toolpad-core/src/useDialogs/DialogsProvider.tsx
+++ b/packages/toolpad-core/src/useDialogs/DialogsProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 import invariant from 'invariant';
 import * as React from 'react';
+import useEventCallback from '@mui/utils/useEventCallback';
 import { DialogsContext } from './DialogsContext';
 import type { DialogComponent, OpenDialog, OpenDialogOptions } from './useDialogs';
 
@@ -37,7 +38,7 @@ function DialogsProvider(props: DialogProviderProps) {
   const keyPrefix = React.useId();
   const nextId = React.useRef(0);
 
-  const requestDialog = React.useCallback<OpenDialog>(
+  const requestDialog = useEventCallback<OpenDialog>(
     function open<P, R>(
       Component: DialogComponent<P, R>,
       payload: P,
@@ -65,11 +66,10 @@ function DialogsProvider(props: DialogProviderProps) {
 
       setStack((prevStack) => [...prevStack, newEntry]);
       return promise;
-    },
-    [keyPrefix],
+    }
   );
 
-  const closeDialogUi = React.useCallback(
+  const closeDialogUi = useEventCallback(
     function closeDialogUi<R>(dialog: Promise<R>) {
       setStack((prevStack) =>
         prevStack.map((entry) => (entry.promise === dialog ? { ...entry, open: false } : entry)),
@@ -78,11 +78,11 @@ function DialogsProvider(props: DialogProviderProps) {
         // wait for closing animation
         setStack((prevStack) => prevStack.filter((entry) => entry.promise !== dialog));
       }, unmountAfter);
-    },
-    [unmountAfter],
+    }
   );
 
-  const closeDialog = React.useCallback(
+
+  const closeDialog = useEventCallback(
     async function closeDialog<R>(dialog: Promise<R>, result: R) {
       const entryToClose = stack.find((entry) => entry.promise === dialog);
       invariant(entryToClose, 'dialog not found');
@@ -91,7 +91,6 @@ function DialogsProvider(props: DialogProviderProps) {
       closeDialogUi(dialog);
       return dialog;
     },
-    [stack, closeDialogUi],
   );
 
   const contextValue = React.useMemo(

--- a/packages/toolpad-core/src/useDialogs/useDialogs.test.tsx
+++ b/packages/toolpad-core/src/useDialogs/useDialogs.test.tsx
@@ -214,7 +214,7 @@ describe('useDialogs', () => {
 
       expect(within(dialog).getByText('Hello')).toBeTruthy();
 
-      await result.current.close(theDialog);
+      await result.current.close(theDialog, null);
 
       rerender();
 

--- a/packages/toolpad-core/src/useDialogs/useDialogs.test.tsx
+++ b/packages/toolpad-core/src/useDialogs/useDialogs.test.tsx
@@ -195,5 +195,30 @@ describe('useDialogs', () => {
 
       expect(await dialogResult).toBe('I am result');
     });
+
+    test('can close imperatively', async () => {
+      function CustomDialog({ open, onClose }: DialogProps) {
+        return open ? (
+          <div role="dialog">
+            Hello <button onClick={() => onClose()}>Close me</button>
+          </div>
+        ) : null;
+      }
+      const { result, rerender } = renderHook(() => useDialogs(), { wrapper: TestWrapper });
+
+      const theDialog = result.current.open(CustomDialog);
+
+      const dialog = await screen.findByRole('dialog');
+
+      rerender();
+
+      expect(within(dialog).getByText('Hello')).toBeTruthy();
+
+      await result.current.close(theDialog);
+
+      rerender();
+
+      expect(screen.queryByRole('dialog')).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
Stabilize the context value. Event handlers are holding references to it and are operating on outdated state. Eventually we should implement it like https://github.com/mui/toolpad/pull/4628 but in the meantime this should work.

Closes https://github.com/mui/toolpad/issues/4706