### PR TITLE
[docs] Remove email as a way to get support

### DIFF
--- a/docs/data/toolpad/core/introduction/support.md
+++ b/docs/data/toolpad/core/introduction/support.md
@@ -24,13 +24,13 @@ If you think you've found a bug, or you have a new feature idea:
 ### Bug reproductions
 
 We require bug reports to be accompanied by a **minimal reproduction**.
-It significantly increases the odds of fixing the problem.
+This significantly increases the odds of fixing the problem.
 
 ## Stack Overflow
 
 We use Stack Overflow for how-to questions. Answers are crowdsourced from expert developers in the Toolpad community as well as Toolpad maintainers.
 
-You can search through existing questions and answers to see if someone has asked a similar question using the [toolpad tags](https://stackoverflow.com/questions/tagged/toolpad):
+You can search through existing questions and answers to see if someone has asked a similar question using the [toolpad tags](https://stackoverflow.com/questions/tagged/toolpad).
 
 If you can't find your answer, [ask a new question](https://stackoverflow.com/questions/ask?tags=reactjs%20toolpad) using the relevant tags.
 
@@ -43,9 +43,9 @@ You can use it to share what you're working on and connect with other developers
 
 ### Discord
 
-We have a [Discord Server](https://mui.com/r/discord/) to bring the Toolpad community together.
+We have a [Discord server](https://mui.com/r/discord/) to bring the Toolpad community together.
 Looking forward to seeing you there!
 
 :::warning
-Please note that there is a single Discord server for all MUI's company products, so you should post in the "toolpad‑core" channel.
+Please note that Toolpad's community is part of the larger MUI Discord server—look for the "toolpad-core" channel once you're in.
 :::

--- a/docs/data/toolpad/core/introduction/support.md
+++ b/docs/data/toolpad/core/introduction/support.md
@@ -1,49 +1,51 @@
 # Support
 
-<p class="description">From community guidance to critical business support, we're here to help.</p>
+<p class="description">Learn how to get support for Toolpad Core, including feature requests, bug fixes, and technical support from the team.</p>
 
-## Community help
+## GitHub
 
-Welcome to the MUI community as a Toolpad Core user!
-These are the best places to start asking questions and looking for answers when you need help.
+We use GitHub issues as a bug and feature request tracker.
 
-### GitHub
+If you think you've found a bug, or you have a new feature idea:
 
-Toolpad uses GitHub issues to track bug reports and feature requests.
+1. Please start by [making sure it hasn't already been reported or fixed](https://github.com/mui/toolpad/issues?q=is%3Aopen+is%3Aclosed).
+   You can search through existing issues and pull requests to see if someone has reported one similar to yours.
+2. Then, if no duplicates exist, [open an issue](https://github.com/mui/toolpad/issues/new/choose) in the Toolpad repository.
 
-If you think you've found a bug in the codebase, or you have an idea for a new feature, please [search the issues on GitHub](https://github.com/mui/toolpad/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed) before opening a new one, to ensure you're not creating a duplicate.
+### New issue guidelines
 
-- [Open an issue on GitHub](https://github.com/mui/toolpad/issues/new/choose) for issues or feature requests.
-- [Start a GitHub discussion](https://github.com/mui/toolpad/discussions) for a broad topic. Here you can engage with the team and the discussion would likely result in one or more GitHub issues.
-
-#### New issue guidelines
-
-- Please follow one of the issue templates provided on GitHub.
+- Please follow one the issue templates provided on GitHub.
 - Please use a succinct description that helps others find similar issues.
   - ❌ _"It doesn't work"_
   - ✅ _"Add support for {{new feature}}"_
 - Please don't group multiple topics in one issue.
 - Please don't comment "+1" on an issue. It spams the maintainers and doesn't help move the issue forward. Use GitHub reactions instead (👍).
 
-### Discord
+### Bug reproductions
 
-Toolpad is also present on Discord, you can connect with other users and get help from the community. To join, simply click on this [Discord server](https://mui.com/r/discord/) and follow the instructions. Looking forward to seeing you there!
+We require bug reports to be accompanied by a **minimal reproduction**.
+It significantly increases the odds of fixing the problem.
 
-:::warning
-Please note that there is a single Discord server for all MUI products and you should post in the Toolpad channel.
-:::
+## Stack Overflow
 
-### Stack Overflow
+We use Stack Overflow for how-to questions. Answers are crowdsourced from expert developers in the Toolpad community as well as Toolpad maintainers.
 
-Stack Overflow contains a wealth of information about MUI products. Toolpad Core is a new product and you can start by [posting a question](https://stackoverflow.com/questions/tagged/toolpad) to get help from community experts as well as maintainers.
+You can search through existing questions and answers to see if someone has asked a similar question using the [toolpad tags](https://stackoverflow.com/questions/tagged/toolpad):
+
+If you can't find your answer, [ask a new question](https://stackoverflow.com/questions/ask?tags=reactjs%20toolpad) using the relevant tags.
+
+## Community
 
 ### Social media
 
 Toolpad has a growing presence on [Twitter/X](https://twitter.com/Toolpad_).
 You can use it to share what you're working on and connect with other developers.
 
-Please keep in mind that we don't actively monitor direct messages on the company's social media accounts, so this is _not_ a good way to get in touch with us directly.
+### Discord
 
-### Direct email
+We have a [Discord Server](https://mui.com/r/discord/) to bring the Toolpad community together.
+Looking forward to seeing you there!
 
-If email is your thing, the team can be directly reached at toolpad@mui.com.
+:::warning
+Please note that there is a single Discord server for all MUI's company products, so you should post in the Toolpad channel.
+:::

--- a/docs/data/toolpad/core/introduction/support.md
+++ b/docs/data/toolpad/core/introduction/support.md
@@ -47,5 +47,5 @@ We have a [Discord Server](https://mui.com/r/discord/) to bring the Toolpad comm
 Looking forward to seeing you there!
 
 :::warning
-Please note that there is a single Discord server for all MUI's company products, so you should post in the Toolpad channel.
+Please note that there is a single Discord server for all MUI's company products, so you should post in the "toolpad‑core" channel.
 :::

--- a/docs/data/toolpad/core/introduction/support.md
+++ b/docs/data/toolpad/core/introduction/support.md
@@ -46,6 +46,6 @@ You can use it to share what you're working on and connect with other developers
 We have a [Discord server](https://mui.com/r/discord/) to bring the Toolpad community together.
 Looking forward to seeing you there!
 
-:::warning
+:::info
 Please note that Toolpad's community is part of the larger MUI Discord server—look for the "toolpad-core" channel once you're in.
 :::

--- a/docs/data/toolpad/studio/getting-started/support.md
+++ b/docs/data/toolpad/studio/getting-started/support.md
@@ -38,5 +38,5 @@ You can use it to share what you're working on and connect with other developers
 Toolpad Studio is also present on Discord, you can connect with other Toolpad Studio users and get help from the community. To join, simply click on this [Discord server](https://mui.com/r/discord/) and follow the instructions. Looking forward to seeing you there!
 
 :::warning
-Please note that there is a single Discord server for all MUI products and you should post in the Toolpad Studio channel.
+Please note that there is a single Discord server for all MUI products and you should post in the "toolpad‑studio" channel.
 :::

--- a/docs/data/toolpad/studio/getting-started/support.md
+++ b/docs/data/toolpad/studio/getting-started/support.md
@@ -24,7 +24,7 @@ If you think you've found a bug, or you have a new feature idea:
 ### Bug reproductions
 
 We require bug reports to be accompanied by a **minimal reproduction**.
-It significantly increases the odds of fixing the problem.
+This significantly increases the odds of fixing the problem.
 
 ## Community
 
@@ -35,8 +35,10 @@ You can use it to share what you're working on and connect with other developers
 
 ### Discord
 
-Toolpad Studio is also present on Discord, you can connect with other Toolpad Studio users and get help from the community. To join, simply click on this [Discord server](https://mui.com/r/discord/) and follow the instructions. Looking forward to seeing you there!
+Toolpad Studio is also present on Discord, where you can connect with other users and get help from the community. 
+To join, head to the [MUI Discord server](https://mui.com/r/discord/) and follow the instructions provided. 
+Looking forward to seeing you there!
 
 :::warning
-Please note that there is a single Discord server for all MUI products and you should post in the "toolpad‑studio" channel.
+Please note that Toolpad's community is part of the larger MUI Discord server—look for the "toolpad-studio" channel once you're in.
 :::

--- a/docs/data/toolpad/studio/getting-started/support.md
+++ b/docs/data/toolpad/studio/getting-started/support.md
@@ -1,30 +1,37 @@
 # Support
 
-<p class="description">From community guidance to critical business support, we're here to help.</p>
+<p class="description">Learn how to get support for Toolpad Studio, including feature requests, bug fixes, and technical support from the team.</p>
 
-## Community help
+## GitHub
 
-Welcome to the Toolpad Studio community!
-Toolpad Studio is used by developers and teams all around the world, many of whom actively engage with the community through various online platforms.
-These are the best places to start asking questions and looking for answers when you need help.
+We use GitHub issues as a bug and feature request tracker.
 
-### GitHub
+If you think you've found a bug, or you have a new feature idea:
 
-Toolpad Studio uses GitHub issues to track bug reports and feature requests.
+1. Please start by [making sure it hasn't already been reported or fixed](https://github.com/mui/toolpad/issues?q=is%3Aopen+is%3Aclosed).
+   You can search through existing issues and pull requests to see if someone has reported one similar to yours.
+2. Then, if no duplicates exist, [open an issue](https://github.com/mui/toolpad/issues/new/choose) in the Toolpad repository.
 
-If you think you've found a bug in the codebase, or you have an idea for a new feature, please [search the issues on GitHub](https://github.com/mui/toolpad/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed) before opening a new one, to ensure you're not creating a duplicate.
+### New issue guidelines
 
-- [Open an issue on Toolpad Studio](https://github.com/mui/toolpad/issues/new/choose) for issues or feature requests.
-- [Start a GitHub discussion](https://github.com/mui/toolpad/discussions) for a broad topic. Here you can engage with the team and the discussion would likely result in one or more GitHub issues.
-
-#### New issue guidelines
-
-- Please follow one of the issue templates provided on GitHub.
+- Please follow one the issue templates provided on GitHub.
 - Please use a succinct description that helps others find similar issues.
   - ❌ _"It doesn't work"_
   - ✅ _"Add support for {{new feature}}"_
 - Please don't group multiple topics in one issue.
 - Please don't comment "+1" on an issue. It spams the maintainers and doesn't help move the issue forward. Use GitHub reactions instead (👍).
+
+### Bug reproductions
+
+We require bug reports to be accompanied by a **minimal reproduction**.
+It significantly increases the odds of fixing the problem.
+
+## Community
+
+### Social media
+
+Toolpad Studio has a growing presence on [Twitter/X](https://x.com/Toolpad_).
+You can use it to share what you're working on and connect with other developers.
 
 ### Discord
 
@@ -33,18 +40,3 @@ Toolpad Studio is also present on Discord, you can connect with other Toolpad St
 :::warning
 Please note that there is a single Discord server for all MUI products and you should post in the Toolpad Studio channel.
 :::
-
-### Stack Overflow
-
-Stack Overflow contains a wealth of information about MUI products. Toolpad Studio is a new product and you can start by [posting a question](https://stackoverflow.com/questions/tagged/toolpad) to get help from community experts as well as maintainers.
-
-### Social media
-
-Toolpad Studio has a growing presence on [Twitter/X](https://x.com/Toolpad_).
-You can use it to share what you're working on and connect with other developers.
-
-Please keep in mind that we don't actively monitor direct messages on the company's social media accounts, so this is _not_ a good way to get in touch with us directly.
-
-### Direct email
-
-If email is your thing, the team can be directly reached at toolpad@mui.com.

--- a/docs/data/toolpad/studio/getting-started/support.md
+++ b/docs/data/toolpad/studio/getting-started/support.md
@@ -35,10 +35,10 @@ You can use it to share what you're working on and connect with other developers
 
 ### Discord
 
-Toolpad Studio is also present on Discord, where you can connect with other users and get help from the community. 
-To join, head to the [MUI Discord server](https://mui.com/r/discord/) and follow the instructions provided. 
+Toolpad Studio is also present on Discord, where you can connect with other users and get help from the community.
+To join, head to the [MUI Discord server](https://mui.com/r/discord/) and follow the instructions provided.
 Looking forward to seeing you there!
 
-:::warning
+:::info
 Please note that Toolpad's community is part of the larger MUI Discord server—look for the "toolpad-studio" channel once you're in.
 :::


### PR DESCRIPTION
So far, I haven't seen one great use of email to provide support: https://groups.google.com/a/mui.com/g/toolpad. It feels pretty bad UX as nobody else from the community can jump in to help.

As we plan to put Toolpad on a power nap, it's especially important that people don't waste their time sending emails nobody will answer.

Preview:

- https://deploy-preview-4716--mui-toolpad-docs.netlify.app/toolpad/core/introduction/support/
- https://deploy-preview-4716--mui-toolpad-docs.netlify.app/toolpad/studio/getting-started/support/

---

I used the opportunity to sync the page with the template model: https://mui.com/material-ui/getting-started/support/.
It looks like we need to fix https://base-ui.com/react/overview/about too: https://github.com/mui/base-ui/issues/1519.