### PR TITLE
[docs] Add "new" label to CRUD item

### DIFF
--- a/docs/data/toolpad/core/pages.ts
+++ b/docs/data/toolpad/core/pages.ts
@@ -107,6 +107,7 @@ const pages: MuiPage[] = [
           {
             pathname: '/toolpad/core/react-crud',
             title: 'Crud',
+            newFeature: true,
           },
         ],
       },


### PR DESCRIPTION
Add label in docs for this release.

<img width="1989" alt="Screenshot 2025-03-11 at 13 29 45" src="https://github.com/user-attachments/assets/45510788-fb80-4f59-996b-27a846395f76" />