### PR TITLE
[docs] Fix CRUD usage in docs

### DIFF
--- a/docs/data/toolpad/core/all-components/all-components.md
+++ b/docs/data/toolpad/core/all-components/all-components.md
@@ -4,7 +4,7 @@
 
 - [Account](/toolpad/core/react-account/)
 - [App Provider](/toolpad/core/react-app-provider/)
-- [Crud](/toolpad/core/react-crud/)
+- [CRUD](/toolpad/core/react-crud/)
 - [Dashboard Layout](/toolpad/core/react-dashboard-layout/)
 - [Page Container](/toolpad/core/react-page-container/)
 - [Sign-in Page](/toolpad/core/react-sign-in-page/)

--- a/docs/data/toolpad/core/components/crud/crud.md
+++ b/docs/data/toolpad/core/components/crud/crud.md
@@ -8,7 +8,7 @@ components: Crud, CrudProvider, List, Show, Create, Edit, CrudForm
 
 <p class="description">The CRUD component provides UIs to interact with data from any data source.</p>
 
-With the CRUD components you can easily generate pages where items from your data source can be listed in a table, shown individually in detail, or created and edited with forms. All with minimal configuration from a single data source definition.
+With the `Crud` component and its subcomponents you can easily generate pages where items from your data source can be listed in a table, shown individually in detail, or created and edited with forms. All with minimal configuration from a single data source definition.
 
 ## Demo
 

--- a/docs/data/toolpad/core/components/crud/crud.md
+++ b/docs/data/toolpad/core/components/crud/crud.md
@@ -1,14 +1,14 @@
 ---
 productId: toolpad-core
-title: Crud
+title: CRUD
 components: Crud, CrudProvider, List, Show, Create, Edit, CrudForm
 ---
 
-# Crud
+# CRUD
 
-<p class="description">The Crud component provides UIs to interact with data from any data source.</p>
+<p class="description">The CRUD component provides UIs to interact with data from any data source.</p>
 
-With the `Crud` component and its subcomponents you can easily generate pages where items from your data source can be listed in a table, shown individually in detail, or created and edited with forms. All with minimal configuration from a single data source definition.
+With the CRUD component and its subcomponents you can easily generate pages where items from your data source can be listed in a table, shown individually in detail, or created and edited with forms. All with minimal configuration from a single data source definition.
 
 ## Demo
 

--- a/docs/data/toolpad/core/components/crud/crud.md
+++ b/docs/data/toolpad/core/components/crud/crud.md
@@ -8,7 +8,7 @@ components: Crud, CrudProvider, List, Show, Create, Edit, CrudForm
 
 <p class="description">The CRUD component provides UIs to interact with data from any data source.</p>
 
-With the CRUD component and its subcomponents you can easily generate pages where items from your data source can be listed in a table, shown individually in detail, or created and edited with forms. All with minimal configuration from a single data source definition.
+With the CRUD components you can easily generate pages where items from your data source can be listed in a table, shown individually in detail, or created and edited with forms. All with minimal configuration from a single data source definition.
 
 ## Demo
 

--- a/docs/data/toolpad/core/pages.ts
+++ b/docs/data/toolpad/core/pages.ts
@@ -106,7 +106,7 @@ const pages: MuiPage[] = [
         children: [
           {
             pathname: '/toolpad/core/react-crud',
-            title: 'Crud',
+            title: 'CRUD',
             newFeature: true,
           },
         ],

--- a/docs/pages/toolpad/core/api/create.json
+++ b/docs/pages/toolpad/core/api/create.json
@@ -18,6 +18,6 @@
   "muiName": "Create",
   "filename": "/packages/toolpad-core/src/Crud/Create.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">Crud</a></li></ul>",
+  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">CRUD</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/toolpad/core/api/crud-form.json
+++ b/docs/pages/toolpad/core/api/crud-form.json
@@ -33,6 +33,6 @@
   "muiName": "CrudForm",
   "filename": "/packages/toolpad-core/src/Crud/CrudForm.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">Crud</a></li></ul>",
+  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">CRUD</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/toolpad/core/api/crud-provider.json
+++ b/docs/pages/toolpad/core/api/crud-provider.json
@@ -14,6 +14,6 @@
   "muiName": "CrudProvider",
   "filename": "/packages/toolpad-core/src/Crud/CrudProvider.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">Crud</a></li></ul>",
+  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">CRUD</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/toolpad/core/api/crud.json
+++ b/docs/pages/toolpad/core/api/crud.json
@@ -22,6 +22,6 @@
   "muiName": "Crud",
   "filename": "/packages/toolpad-core/src/Crud/Crud.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">Crud</a></li></ul>",
+  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">CRUD</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/toolpad/core/api/edit.json
+++ b/docs/pages/toolpad/core/api/edit.json
@@ -16,6 +16,6 @@
   "muiName": "Edit",
   "filename": "/packages/toolpad-core/src/Crud/Edit.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">Crud</a></li></ul>",
+  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">CRUD</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/toolpad/core/api/list.json
+++ b/docs/pages/toolpad/core/api/list.json
@@ -37,6 +37,6 @@
   "muiName": "List",
   "filename": "/packages/toolpad-core/src/Crud/List.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">Crud</a></li></ul>",
+  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">CRUD</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/toolpad/core/api/show.json
+++ b/docs/pages/toolpad/core/api/show.json
@@ -17,6 +17,6 @@
   "muiName": "Show",
   "filename": "/packages/toolpad-core/src/Crud/Show.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">Crud</a></li></ul>",
+  "demos": "<ul><li><a href=\"/toolpad/core/react-crud/\">CRUD</a></li></ul>",
   "cssComponent": false
 }

--- a/packages/toolpad-core/src/Crud/Create.tsx
+++ b/packages/toolpad-core/src/Crud/Create.tsx
@@ -44,7 +44,7 @@ export interface CreateProps<D extends DataModel> {
  *
  * Demos:
  *
- * - [Crud](https://mui.com/toolpad/core/react-crud/)
+ * - [CRUD](https://mui.com/toolpad/core/react-crud/)
  *
  * API:
  *

--- a/packages/toolpad-core/src/Crud/Crud.tsx
+++ b/packages/toolpad-core/src/Crud/Crud.tsx
@@ -40,7 +40,7 @@ export interface CrudProps<D extends DataModel> {
  *
  * Demos:
  *
- * - [Crud](https://mui.com/toolpad/core/react-crud/)
+ * - [CRUD](https://mui.com/toolpad/core/react-crud/)
  *
  * API:
  *

--- a/packages/toolpad-core/src/Crud/CrudForm.tsx
+++ b/packages/toolpad-core/src/Crud/CrudForm.tsx
@@ -84,7 +84,7 @@ export interface CrudFormProps<D extends DataModel> {
  *
  * Demos:
  *
- * - [Crud](https://mui.com/toolpad/core/react-crud/)
+ * - [CRUD](https://mui.com/toolpad/core/react-crud/)
  *
  * API:
  *

--- a/packages/toolpad-core/src/Crud/CrudProvider.tsx
+++ b/packages/toolpad-core/src/Crud/CrudProvider.tsx
@@ -20,7 +20,7 @@ export interface CrudProviderProps<D extends DataModel> {
  *
  * Demos:
  *
- * - [Crud](https://mui.com/toolpad/core/react-crud/)
+ * - [CRUD](https://mui.com/toolpad/core/react-crud/)
  *
  * API:
  *

--- a/packages/toolpad-core/src/Crud/Edit.tsx
+++ b/packages/toolpad-core/src/Crud/Edit.tsx
@@ -172,7 +172,7 @@ export interface EditProps<D extends DataModel> {
  *
  * Demos:
  *
- * - [Crud](https://mui.com/toolpad/core/react-crud/)
+ * - [CRUD](https://mui.com/toolpad/core/react-crud/)
  *
  * API:
  *

--- a/packages/toolpad-core/src/Crud/List.tsx
+++ b/packages/toolpad-core/src/Crud/List.tsx
@@ -116,7 +116,7 @@ export interface ListProps<D extends DataModel> {
  *
  * Demos:
  *
- * - [Crud](https://mui.com/toolpad/core/react-crud/)
+ * - [CRUD](https://mui.com/toolpad/core/react-crud/)
  *
  * API:
  *

--- a/packages/toolpad-core/src/Crud/Show.tsx
+++ b/packages/toolpad-core/src/Crud/Show.tsx
@@ -51,7 +51,7 @@ export interface ShowProps<D extends DataModel> {
  *
  * Demos:
  *
- * - [Crud](https://mui.com/toolpad/core/react-crud/)
+ * - [CRUD](https://mui.com/toolpad/core/react-crud/)
  *
  * API:
  *


### PR DESCRIPTION
Fix `Crud` naming to "CRUD" in docs where it makes sense to.
Addresses https://github.com/orgs/mui/projects/9/views/1?sliceBy%5Bvalue%5D=v0.14.0&pane=issue&itemId=102303576

https://deploy-preview-4783--mui-toolpad-docs.netlify.app/toolpad/core/react-crud/