### PR TITLE
fix: Unwarp Dialog promises created by confirm, prompt, and alert to enable closing these dialogs imperatively

### DIFF
--- a/packages/toolpad-core/src/useDialogs/useDialogs.test.tsx
+++ b/packages/toolpad-core/src/useDialogs/useDialogs.test.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { describe, test, expect } from 'vitest';
-import { renderHook, within, screen } from '@testing-library/react';
+import { renderHook, within, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { DialogProps, useDialogs } from './useDialogs';
 import { DialogsProvider } from './DialogsProvider';
@@ -37,6 +37,20 @@ describe('useDialogs', () => {
       expect(await dialogResult).toBeUndefined();
 
       expect(screen.queryByRole('dialog')).toBeFalsy();
+    });
+
+    test('can close imperatively', async () => {
+      const { result } = renderHook(() => useDialogs(), { wrapper: TestWrapper });
+
+      const theDialog = result.current.alert('Hello');
+
+      const dialog = await screen.findByRole('dialog');
+
+      await waitFor(() => expect(within(dialog).getByText('Hello')).toBeTruthy());
+
+      await result.current.close(theDialog, undefined);
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeFalsy());
     });
   });
 
@@ -79,6 +93,20 @@ describe('useDialogs', () => {
       expect(await dialogResult).toBe(false);
 
       expect(screen.queryByRole('dialog')).toBeFalsy();
+    });
+
+    test('can close imperatively', async () => {
+      const { result } = renderHook(() => useDialogs(), { wrapper: TestWrapper });
+
+      const theDialog = result.current.confirm('Hello');
+
+      const dialog = await screen.findByRole('dialog');
+
+      await waitFor(() => expect(within(dialog).getByText('Hello')).toBeTruthy());
+
+      await result.current.close(theDialog, true);
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeFalsy());
     });
   });
 
@@ -125,6 +153,20 @@ describe('useDialogs', () => {
       expect(await dialogResult).toBe(null);
 
       expect(screen.queryByRole('dialog')).toBeFalsy();
+    });
+
+    test('can close imperatively', async () => {
+      const { result } = renderHook(() => useDialogs(), { wrapper: TestWrapper });
+
+      const theDialog = result.current.prompt('Hello');
+
+      const dialog = await screen.findByRole('dialog');
+
+      await waitFor(() => expect(within(dialog).getByText('Hello')).toBeTruthy());
+
+      await result.current.close(theDialog, 'goodbye');
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeFalsy());
     });
   });
 
@@ -204,21 +246,17 @@ describe('useDialogs', () => {
           </div>
         ) : null;
       }
-      const { result, rerender } = renderHook(() => useDialogs(), { wrapper: TestWrapper });
+      const { result } = renderHook(() => useDialogs(), { wrapper: TestWrapper });
 
       const theDialog = result.current.open(CustomDialog);
 
       const dialog = await screen.findByRole('dialog');
 
-      rerender();
-
-      expect(within(dialog).getByText('Hello')).toBeTruthy();
+      await waitFor(() => expect(within(dialog).getByText('Hello')).toBeTruthy());
 
       await result.current.close(theDialog, null);
 
-      rerender();
-
-      expect(screen.queryByRole('dialog')).toBeFalsy();
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeFalsy());
     });
   });
 });

--- a/packages/toolpad-core/src/useDialogs/useDialogs.tsx
+++ b/packages/toolpad-core/src/useDialogs/useDialogs.tsx
@@ -338,20 +338,17 @@ export function useDialogs(): DialogHook {
   const { open, close } = useNonNullableContext(DialogsContext);
 
   const alert = React.useCallback<OpenAlertDialog>(
-    async (msg, { onClose, ...options } = {}) =>
-      open(AlertDialog, { ...options, msg }, { onClose }),
+    (msg, { onClose, ...options } = {}) => open(AlertDialog, { ...options, msg }, { onClose }),
     [open],
   );
 
   const confirm = React.useCallback<OpenConfirmDialog>(
-    async (msg, { onClose, ...options } = {}) =>
-      open(ConfirmDialog, { ...options, msg }, { onClose }),
+    (msg, { onClose, ...options } = {}) => open(ConfirmDialog, { ...options, msg }, { onClose }),
     [open],
   );
 
   const prompt = React.useCallback<OpenPromptDialog>(
-    async (msg, { onClose, ...options } = {}) =>
-      open(PromptDialog, { ...options, msg }, { onClose }),
+    (msg, { onClose, ...options } = {}) => open(PromptDialog, { ...options, msg }, { onClose }),
     [open],
   );
 


### PR DESCRIPTION
Because the useCallback utilized async declarations around wrapping the open() function, it created a new Promise around the return value of open() making it impossible for consumers to utilize the promise to call `close()` because the promise ref no longer matched

Signed-off-by: Tyler Robinson <tydiz936@dizware.dev>
Update useDialogs.test.tsx

Signed-off-by: Tyler Robinson <tydiz936@dizware.dev>
Clean up


Before applying the fix: 

![image](https://github.com/user-attachments/assets/45342961-c8ef-4ec9-9f44-40a68aa47224)


After applying the fix:

![image](https://github.com/user-attachments/assets/cb838561-e22f-4206-8270-f4a0e3005223)


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I've read and followed the [contributing guide](https://github.com/mui/toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
~~- [ ] I've updated the relevant documentation for any new or updated feature.~~ - Not relevant
~~- [ ] I've linked relevant GitHub issue with "Closes #<issue id>".~~ - Not relevant
- [x] I've added a visual demonstration in the form of a screenshot or video.
