### PR TITLE
[core] Upgrade monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/internal-docs-utils": "1.0.16",
     "@mui/internal-markdown": "1.0.25",
     "@mui/internal-scripts": "1.0.33",
-    "@mui/monorepo": "github:mui/material-ui#ae19b3bf8f5f14a47fc2232ddc38eaef7621dbe3",
+    "@mui/monorepo": "github:mui/material-ui#abd8f63bc0b8d681b3bfbe47486508c94ea23609",
     "@mui/x-charts": "7.28.0",
     "@next/eslint-plugin-next": "14.2.25",
     "@playwright/test": "1.47.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: 1.0.33
         version: 1.0.33
       '@mui/monorepo':
-        specifier: github:mui/material-ui#ae19b3bf8f5f14a47fc2232ddc38eaef7621dbe3
-        version: https://codeload.github.com/mui/material-ui/tar.gz/ae19b3bf8f5f14a47fc2232ddc38eaef7621dbe3(@babel/core@7.26.10)(@types/express@5.0.1)(encoding@0.1.13)
+        specifier: github:mui/material-ui#abd8f63bc0b8d681b3bfbe47486508c94ea23609
+        version: https://codeload.github.com/mui/material-ui/tar.gz/abd8f63bc0b8d681b3bfbe47486508c94ea23609(@babel/core@7.26.10)(@types/express@5.0.1)(encoding@0.1.13)
       '@mui/x-charts':
         specifier: 7.28.0
         version: 7.28.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2618,10 +2618,10 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/ae19b3bf8f5f14a47fc2232ddc38eaef7621dbe3':
-    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/ae19b3bf8f5f14a47fc2232ddc38eaef7621dbe3}
-    version: 7.0.0-rc.0
-    engines: {pnpm: 10.6.5}
+  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/abd8f63bc0b8d681b3bfbe47486508c94ea23609':
+    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/abd8f63bc0b8d681b3bfbe47486508c94ea23609}
+    version: 7.0.1
+    engines: {pnpm: 10.7.0}
 
   '@mui/private-theming@5.16.12':
     resolution: {integrity: sha512-hhLTSZxsazwZZ4bUAKgFcbsnfCrwizSnJI7/bXf/R9/tZkZBy+bKY05/Au/bIgGKzuZ4KTlKlPn+U/uufEXrNw==}
@@ -11545,7 +11545,7 @@ snapshots:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0)
       '@types/react': 19.0.12
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/ae19b3bf8f5f14a47fc2232ddc38eaef7621dbe3(@babel/core@7.26.10)(@types/express@5.0.1)(encoding@0.1.13)':
+  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/abd8f63bc0b8d681b3bfbe47486508c94ea23609(@babel/core@7.26.10)(@types/express@5.0.1)(encoding@0.1.13)':
     dependencies:
       '@googleapis/sheets': 9.6.0(encoding@0.1.13)
       '@netlify/functions': 3.0.4


### PR DESCRIPTION
This should fix those broken links in 

<img width="885" alt="SCR-20250331-cqea" src="https://github.com/user-attachments/assets/c71d0c1c-69a5-4feb-a5a0-49399ead51b7" />

reported in https://app.ahrefs.com/site-audit/2944028/data-explorer?columns=pageRating%2Curl%2Ctraffic%2Ccompliant%2ChreflangLink%2ChreflangIssues%2ChreflangGroupHash%2CincomingHreflang%2CincomingAllLinks&current=26-03-2025T031007P0100&filterId=a4a2dd9cd2faf702cf7f5f22b1fb77ef&issueId=c64d7d54-d0f4-11e7-8ed1-001e67ed4656

Preview: https://deploy-preview-4819--mui-toolpad-docs.netlify.app/toolpad/