### PR TITLE
Corrected 'Returns' section grammer

### DIFF
--- a/docs/data/toolpad/core/components/persistent-state/use-local-storage-state-api.md
+++ b/docs/data/toolpad/core/components/persistent-state/use-local-storage-state-api.md
@@ -38,4 +38,4 @@ const [state, setState] = useLocalStorageState('my-key', 'initial value');
 
 **Returns**
 
-`[T | null, React.Dispatch<React.SetStateAction<T | null>>]` Similar to `React.setState` result, it returns an tupple where the first item represents the state, and the second item a setter for the state.
+`[T | null, React.Dispatch<React.SetStateAction<T | null>>]` Similar to `React.setState` result, it returns a tupple where the first item represents the state, and the second item is a setter for the state.


### PR DESCRIPTION
"an tupple" → "a tuple" (use "a" before words starting with a consonant sound).

"a setter" → "is a setter" (to make the second clause a full sentence).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ yes ] I've read and followed the [contributing guide](https://github.com/mui/toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [ yes ] I've updated the relevant documentation for any new or updated feature.
- [ yes ] I've linked relevant GitHub issue with "Closes #<issue id>".
- [ yes ] I've added a visual demonstration in the form of a screenshot or video.
