### PR TITLE
[DashboardLayout] Highlight and text alignment for mini

### DIFF
--- a/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
@@ -275,6 +275,7 @@ function DashboardLayout(props: DashboardLayoutProps) {
             flexDirection: 'column',
             justifyContent: 'space-between',
             overflow: 'auto',
+            scrollbarGutter: isMini ? 'stable' : 'auto',
             pt: navigation[0]?.kind === 'header' && !isMini ? 0 : 2,
             ...(hasDrawerTransitions
               ? getDrawerSxTransitionMixin(isNavigationFullyExpanded, 'padding')

--- a/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
@@ -253,7 +253,7 @@ function DashboardSidebarSubNavigation({
                   sx={{
                     position: 'relative',
                     top: isMini ? -6 : 0,
-                    left: isMini ? 5 : 0,
+                    left: 0,
                   }}
                 >
                   <ListItemIcon
@@ -287,9 +287,9 @@ function DashboardSidebarSubNavigation({
                       sx={{
                         position: 'absolute',
                         bottom: -18,
-                        left: '50%',
+                        left: '45%',
                         transform: 'translateX(-50%)',
-                        fontSize: 10,
+                        fontSize: 9,
                         fontWeight: 500,
                         textAlign: 'center',
                         whiteSpace: 'nowrap',

--- a/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
@@ -127,6 +127,7 @@ function DashboardSidebarSubNavigation({
         mb: depth === 0 && !isPopover ? 4 : 0.5,
         pl: (isPopover ? 1 : 2) * (isPopover ? depth - 1 : depth),
         minWidth: isPopover && depth === 1 ? 240 : 'auto',
+        width: isMini ? MINI_DRAWER_WIDTH : 'auto',
       }}
     >
       {subNavigation.map((navigationItem, navigationItemIndex) => {
@@ -253,7 +254,7 @@ function DashboardSidebarSubNavigation({
                   sx={{
                     position: 'relative',
                     top: isMini ? -6 : 0,
-                    left: 0,
+                    left: isMini ? 5 : 0,
                   }}
                 >
                   <ListItemIcon
@@ -287,9 +288,9 @@ function DashboardSidebarSubNavigation({
                       sx={{
                         position: 'absolute',
                         bottom: -18,
-                        left: '45%',
+                        left: '50%',
                         transform: 'translateX(-50%)',
-                        fontSize: 9,
+                        fontSize: 10,
                         fontWeight: 500,
                         textAlign: 'center',
                         whiteSpace: 'nowrap',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         version: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-compiler:
         specifier: latest
-        version: 19.0.0-beta-e993439-20250405(eslint@8.57.1)
+        version: 19.0.0-beta-ebf51a3-20250411(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: 5.2.0
         version: 5.2.0(eslint@8.57.1)
@@ -5550,8 +5550,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-react-compiler@19.0.0-beta-e993439-20250405:
-    resolution: {integrity: sha512-8ZQU4qGc8NOfsM7u7tf7gXmZ+d4tSK+7BFb+Fvs4s9ItQ12m/G6ttSGxompH/Jq7nXgnJ20EqQRshwVG6GwUdA==}
+  eslint-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411:
+    resolution: {integrity: sha512-R7ncuwbCPFAoeMlS56DGGSJFxmRtlWafYH/iWyep5Ks0RaPqTCL4k5gA87axUBBcITsaIgUGkbqAxDxl8Xfm5A==}
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     peerDependencies:
       eslint: '>=7'
@@ -15192,7 +15192,7 @@ snapshots:
       globals: 13.24.0
       rambda: 7.5.0
 
-  eslint-plugin-react-compiler@19.0.0-beta-e993439-20250405(eslint@8.57.1):
+  eslint-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411(eslint@8.57.1):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/parser': 7.27.0


### PR DESCRIPTION
- Fix https://github.com/mui/toolpad/issues/4835

- use the `MINI_DRAWER_WIDTH`  for the `ul` and passing `scrollbar-gutter: stable` to the `nav` when `isMini` is set, everything being the same in all other modes.

| **Before** | **After** |
|---|---|
| <img src="https://private-user-images.githubusercontent.com/71654184/431696814-395eb98f-e381-4b0d-994b-0f3ef0c8515a.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ2NjU2MzgsIm5iZiI6MTc0NDY2NTMzOCwicGF0aCI6Ii83MTY1NDE4NC80MzE2OTY4MTQtMzk1ZWI5OGYtZTM4MS00YjBkLTk5NGItMGYzZWYwYzg1MTVhLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDE0VDIxMTUzOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTI4YmEzYzBiMWZiMjk0MjUwZjIwNDllMzVjZmU2YTJlYTI3M2NiMDFmNmNkNGZjMjY3ZmIwY2M4OGU2Y2Q2MTEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.-X9nrSkgNZjP-wjBYcSvTIN1N_LpqhUbpeJouZZnBe4" width="400" height="500" /> | <video width="500" alt="Screenshot 2025-04-14 at 3 10 11 PM" src="https://github.com/user-attachments/assets/8d4dc7e7-9cc7-47df-a076-93634c96906a" /> |
