### PR TITLE
[AppProvider] Make theming not require specific HTML attribute name

### DIFF
--- a/docs/data/toolpad/core/components/app-provider/app-provider.md
+++ b/docs/data/toolpad/core/components/app-provider/app-provider.md
@@ -94,7 +94,7 @@ import { ReactRouterAppProvider } from '@toolpad/core/react-router';
 
 An `AppProvider` can set a visual theme for all elements inside it to adopt via the `theme` prop. This prop can be set in a few distinct ways with different advantages and disadvantages:
 
-1. [CSS variables theme](https://mui.com/material-ui/customization/css-theme-variables/overview/): the default and recommended theming option for Toolpad applications, as it is the only option that prevents issues such as [dark-mode SSR flickering](https://github.com/mui/material-ui/issues/27651) and supports both light and dark mode with a single theme definition. The provided default theme in Toolpad is already in this format. **CSS variables themes are only supported when you use `@toolpad/core` with version 5.x of `@mui/material`.**
+1. [CSS variables theme](https://mui.com/material-ui/customization/css-theme-variables/overview/): the default and recommended theming option for Toolpad applications, as it is the only option that prevents issues such as [dark-mode SSR flickering](https://github.com/mui/material-ui/issues/27651) and supports both light and dark mode with a single theme definition. The provided default theme in Toolpad is already in this format.
 2. [Standard Material UI theme](https://mui.com/material-ui/customization/theming/): a single standard Material UI theme can be provided as the only theme to be used.
 3. **Light and dark themes**: two separate Material UI themes can be provided for light and dark mode in an object with the format `{ light: Theme, dark: Theme }`
 

--- a/docs/pages/toolpad/core/api/app-provider.json
+++ b/docs/pages/toolpad/core/api/app-provider.json
@@ -34,7 +34,7 @@
       },
       "default": "null"
     },
-    "theme": { "type": { "name": "object" }, "default": "createTheme()" },
+    "theme": { "type": { "name": "object" }, "default": "createDefaultTheme()" },
     "window": { "type": { "name": "object" }, "default": "window" }
   },
   "name": "AppProvider",

--- a/packages/toolpad-core/src/AppProvider/AppProvider.tsx
+++ b/packages/toolpad-core/src/AppProvider/AppProvider.tsx
@@ -88,7 +88,7 @@ export interface AppProviderProps {
   children: React.ReactNode;
   /**
    * [Theme or themes](https://mui.com/toolpad/core/react-app-provider/#theming) to be used by the app in light/dark mode. A [CSS variables theme](https://mui.com/material-ui/customization/css-theme-variables/overview/) is recommended.
-   * @default createTheme()
+   * @default createDefaultTheme()
    */
   theme?: AppTheme;
   /**
@@ -275,7 +275,7 @@ AppProvider.propTypes /* remove-proptypes */ = {
   }),
   /**
    * [Theme or themes](https://mui.com/toolpad/core/react-app-provider/#theming) to be used by the app in light/dark mode. A [CSS variables theme](https://mui.com/material-ui/customization/css-theme-variables/overview/) is recommended.
-   * @default createTheme()
+   * @default createDefaultTheme()
    */
   theme: PropTypes.object,
   /**

--- a/packages/toolpad-core/src/AppProvider/AppProvider.tsx
+++ b/packages/toolpad-core/src/AppProvider/AppProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { createTheme as createMuiTheme, Theme } from '@mui/material/styles';
+import { createTheme, Theme } from '@mui/material/styles';
 import { NotificationsProvider } from '../useNotifications';
 import { DialogsProvider } from '../useDialogs';
 import {
@@ -129,7 +129,7 @@ export interface AppProviderProps {
 }
 
 function createDefaultTheme(): Theme {
-  return createMuiTheme({
+  return createTheme({
     cssVariables: {
       colorSchemeSelector: 'data-toolpad-color-scheme',
     },

--- a/packages/toolpad-core/src/AppProvider/AppProvider.tsx
+++ b/packages/toolpad-core/src/AppProvider/AppProvider.tsx
@@ -11,7 +11,7 @@ import {
   WindowContext,
 } from '../shared/context';
 import type { LinkProps } from '../shared/Link';
-import { AppThemeProvider, COLOR_SCHEME_ATTRIBUTE } from './AppThemeProvider';
+import { AppThemeProvider } from './AppThemeProvider';
 import { LocalizationProvider, type LocaleText } from './LocalizationProvider';
 
 export interface NavigateOptions {
@@ -128,10 +128,10 @@ export interface AppProviderProps {
   window?: Window;
 }
 
-function createTheme(): Theme {
+function createDefaultTheme(): Theme {
   return createMuiTheme({
     cssVariables: {
-      colorSchemeSelector: COLOR_SCHEME_ATTRIBUTE,
+      colorSchemeSelector: 'data-toolpad-color-scheme',
     },
     colorSchemes: { dark: true },
   });
@@ -151,7 +151,7 @@ function createTheme(): Theme {
 function AppProvider(props: AppProviderProps) {
   const {
     children,
-    theme = createTheme(),
+    theme = createDefaultTheme(),
     branding = null,
     navigation = [],
     localeText,

--- a/packages/toolpad-core/src/AppProvider/AppThemeProvider.tsx
+++ b/packages/toolpad-core/src/AppProvider/AppThemeProvider.tsx
@@ -8,9 +8,8 @@ import { useLocalStorageState } from '../useLocalStorageState';
 import { PaletteModeContext } from '../shared/context';
 import type { AppTheme } from './AppProvider';
 
-export const COLOR_SCHEME_ATTRIBUTE = 'data-toolpad-color-scheme';
-export const COLOR_SCHEME_STORAGE_KEY = 'toolpad-color-scheme';
-export const MODE_STORAGE_KEY = 'toolpad-mode';
+const COLOR_SCHEME_STORAGE_KEY = 'toolpad-color-scheme';
+const MODE_STORAGE_KEY = 'toolpad-mode';
 
 function usePreferredMode(window?: Window) {
   const prefersDarkMode = useMediaQuery(
@@ -127,7 +126,7 @@ function CssVarsThemeProvider(props: CssVarsThemeProviderProps) {
       modeStorageKey={MODE_STORAGE_KEY}
     >
       <InitColorSchemeScript
-        attribute={COLOR_SCHEME_ATTRIBUTE}
+        attribute={theme.colorSchemeSelector}
         colorSchemeStorageKey={COLOR_SCHEME_STORAGE_KEY}
         modeStorageKey={MODE_STORAGE_KEY}
       />


### PR DESCRIPTION
I realized that we probably were requiring the CSS selector in the theme to be `data-toolpad-color-scheme` but this shouldn't be necessary...

Also removed a line from the theming docs that should be outdated by now.