### PR TITLE
Add new `useNavigation` hook

### DIFF
--- a/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomPageItems.js
+++ b/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomPageItems.js
@@ -21,7 +21,7 @@ import {
   DashboardLayout,
   DashboardSidebarPageItem,
 } from '@toolpad/core/DashboardLayout';
-import { useDemoRouter } from '@toolpad/core/internal';
+import { DemoProvider, useDemoRouter } from '@toolpad/core/internal';
 
 const NAVIGATION = [
   {
@@ -210,18 +210,21 @@ function DashboardLayoutCustomPageItems(props) {
   // preview-end
 
   return (
-    <AppProvider
-      navigation={NAVIGATION}
-      router={router}
-      theme={demoTheme}
-      window={demoWindow}
-    >
-      {/* preview-start */}
-      <DashboardLayout renderPageItem={renderPageItem}>
-        <DemoPageContent pathname={router.pathname} />
-      </DashboardLayout>
-      {/* preview-end */}
-    </AppProvider>
+    // Remove this provider when copying and pasting into your project.
+    <DemoProvider window={demoWindow}>
+      <AppProvider
+        navigation={NAVIGATION}
+        router={router}
+        theme={demoTheme}
+        window={demoWindow}
+      >
+        {/* preview-start */}
+        <DashboardLayout renderPageItem={renderPageItem}>
+          <DemoPageContent pathname={router.pathname} />
+        </DashboardLayout>
+        {/* preview-end */}
+      </AppProvider>
+    </DemoProvider>
   );
 }
 

--- a/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomPageItems.tsx
+++ b/docs/data/toolpad/core/components/dashboard-layout/DashboardLayoutCustomPageItems.tsx
@@ -24,7 +24,7 @@ import {
   DashboardLayout,
   DashboardSidebarPageItem,
 } from '@toolpad/core/DashboardLayout';
-import { useDemoRouter } from '@toolpad/core/internal';
+import { DemoProvider, useDemoRouter } from '@toolpad/core/internal';
 
 const NAVIGATION: Navigation = [
   {
@@ -202,17 +202,20 @@ export default function DashboardLayoutCustomPageItems(props: DemoProps) {
   // preview-end
 
   return (
-    <AppProvider
-      navigation={NAVIGATION}
-      router={router}
-      theme={demoTheme}
-      window={demoWindow}
-    >
-      {/* preview-start */}
-      <DashboardLayout renderPageItem={renderPageItem}>
-        <DemoPageContent pathname={router.pathname} />
-      </DashboardLayout>
-      {/* preview-end */}
-    </AppProvider>
+    // Remove this provider when copying and pasting into your project.
+    <DemoProvider window={demoWindow}>
+      <AppProvider
+        navigation={NAVIGATION}
+        router={router}
+        theme={demoTheme}
+        window={demoWindow}
+      >
+        {/* preview-start */}
+        <DashboardLayout renderPageItem={renderPageItem}>
+          <DemoPageContent pathname={router.pathname} />
+        </DashboardLayout>
+        {/* preview-end */}
+      </AppProvider>
+    </DemoProvider>
   );
 }

--- a/docs/data/toolpad/core/components/use-navigation/use-navigation-api.md
+++ b/docs/data/toolpad/core/components/use-navigation/use-navigation-api.md
@@ -23,7 +23,7 @@ Learn about the difference by reading this [guide](https://mui.com/material-ui/g
 
 You can access the current value of the `NavigationContext` by invoking the hook inside your components:
 
-```js
+```tsx
 import { useNavigation } from '@toolpad/core/useNavigation';
 
 function MyComponent() {

--- a/docs/data/toolpad/core/components/use-navigation/use-navigation-api.md
+++ b/docs/data/toolpad/core/components/use-navigation/use-navigation-api.md
@@ -1,0 +1,64 @@
+# useNavigation API
+
+<p class="description">API reference for the useNavigation hook.</p>
+
+:::success
+For details on the usage of this React hook, visit the demo page:
+
+- [useNavigation](/toolpad/core/react-use-navigation/)
+
+:::
+
+## Import
+
+```js
+import useNavigation from '@toolpad/core/useNavigation';
+// or
+import { useNavigation } from '@toolpad/core';
+```
+
+Learn about the difference by reading this [guide](https://mui.com/material-ui/guides/minimizing-bundle-size/) on minimizing bundle size.
+
+## Usage
+
+You can access the current value of the `NavigationContext` by invoking the hook inside your components:
+
+```js
+import { useNavigation } from '@toolpad/core/useNavigation';
+
+function MyComponent() {
+  // ...
+  const navigation = useNavigation();
+  // ...
+}
+```
+
+The default `Navigation` interface exported by `@toolpad/core` has the following fields:
+
+```ts
+export type Navigation = NavigationItem[];
+
+export type NavigationItem =
+  | NavigationPageItem
+  | NavigationSubheaderItem
+  | NavigationDividerItem;
+
+export interface NavigationPageItem {
+  kind?: 'page';
+  segment?: string;
+  title?: string;
+  icon?: React.ReactNode;
+  pattern?: string;
+  action?: React.ReactNode;
+  children?: Navigation;
+}
+
+export interface NavigationSubheaderItem {
+  kind: 'header';
+  title: string;
+}
+
+export interface NavigationDividerItem {
+  kind: 'divider';
+}
+```

--- a/docs/data/toolpad/core/components/use-navigation/use-navigation.md
+++ b/docs/data/toolpad/core/components/use-navigation/use-navigation.md
@@ -15,13 +15,13 @@ If this is your first time using Toolpad Core, it's recommended to read about th
 
 When a navigation is set in Toolpad Core, a `NavigationContext` is used to share navigation information among all Toolpad Core components, with the value from the `navigation` prop of the `AppProvider`:
 
-```js
+```tsx
 <AppProvider navigation={navigation}>{props.children}</AppProvider>
 ```
 
 You can access the current value of the `NavigationContext` by invoking the hook inside your components:
 
-```js
+```tsx
 import { useNavigation } from '@toolpad/core/useNavigation';
 
 function MyComponent() {

--- a/docs/data/toolpad/core/components/use-navigation/use-navigation.md
+++ b/docs/data/toolpad/core/components/use-navigation/use-navigation.md
@@ -1,0 +1,36 @@
+---
+productId: toolpad-core
+title: useNavigation
+---
+
+# useNavigation
+
+<p class="description">Toolpad Core exposes an API to access the current navigation definition.</p>
+
+:::info
+If this is your first time using Toolpad Core, it's recommended to read about the [basic concepts](/toolpad/core/introduction/base-concepts/) first.
+:::
+
+## Usage
+
+When a navigation is set in Toolpad Core, a `NavigationContext` is used to share navigation information among all Toolpad Core components, with the value from the `navigation` prop of the `AppProvider`:
+
+```js
+<AppProvider navigation={navigation}>{props.children}</AppProvider>
+```
+
+You can access the current value of the `NavigationContext` by invoking the hook inside your components:
+
+```js
+import { useNavigation } from '@toolpad/core/useNavigation';
+
+function MyComponent() {
+  // ...
+  const navigation = useNavigation();
+  // ...
+}
+```
+
+## Hook API
+
+- [`useNavigation()`](/toolpad/core/react-use-navigation/api/)

--- a/docs/data/toolpad/core/pages.ts
+++ b/docs/data/toolpad/core/pages.ts
@@ -128,6 +128,10 @@ const pages: MuiPage[] = [
             title: 'useSession',
           },
           {
+            pathname: '/toolpad/core/react-use-navigation',
+            title: 'useNavigation',
+          },
+          {
             pathname: '/toolpad/core/react-persistent-state',
             title: 'Persisted state',
           },
@@ -163,6 +167,10 @@ const pages: MuiPage[] = [
           {
             pathname: '/toolpad/core/react-use-session/api',
             title: 'useSession',
+          },
+          {
+            pathname: '/toolpad/core/react-use-navigation/api',
+            title: 'useNavigation',
           },
           {
             pathname: '/toolpad/core/react-persistent-state/use-session-storage-state-api',

--- a/docs/pages/toolpad/core/react-use-navigation/api.js
+++ b/docs/pages/toolpad/core/react-use-navigation/api.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs-toolpad/data/toolpad/core/components/use-navigation/use-navigation-api.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs disableAd {...pageProps} />;
+}

--- a/docs/pages/toolpad/core/react-use-navigation/index.js
+++ b/docs/pages/toolpad/core/react-use-navigation/index.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs-toolpad/data/toolpad/core/components/use-navigation/use-navigation.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs disableAd {...pageProps} />;
+}

--- a/examples/core/auth-nextjs-themed/app/components/CustomDataGrid.tsx
+++ b/examples/core/auth-nextjs-themed/app/components/CustomDataGrid.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DataGrid, DataGridProps } from '@mui/x-data-grid';
 
-export default function CustomizedDataGrid(props: DataGridProps) {
+export default function CustomDataGrid(props: DataGridProps) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <DataGrid

--- a/packages/toolpad-core/src/index.ts
+++ b/packages/toolpad-core/src/index.ts
@@ -18,6 +18,8 @@ export * from './useNotifications';
 
 export * from './useLocalStorageState';
 
+export * from './useNavigation';
+
 export * from './useSession';
 
 export * from './useSessionStorageState';

--- a/packages/toolpad-core/src/useNavigation/index.ts
+++ b/packages/toolpad-core/src/useNavigation/index.ts
@@ -1,0 +1,1 @@
+export * from './useNavigation';

--- a/packages/toolpad-core/src/useNavigation/useNavigation.test.tsx
+++ b/packages/toolpad-core/src/useNavigation/useNavigation.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import * as React from 'react';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+import { renderHook } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
+import type { Navigation } from '../AppProvider';
+import { NavigationContext } from '../shared/context';
+import { useNavigation } from './useNavigation';
+
+const MOCK_NAVIGATION: Navigation = [
+  {
+    kind: 'header',
+    title: 'Main items',
+  },
+  {
+    title: 'Dashboard',
+    icon: <DashboardIcon />,
+  },
+  {
+    segment: 'orders',
+    title: 'Orders',
+    icon: <ShoppingCartIcon />,
+    pattern: 'orders{/:orderId}*',
+  },
+];
+
+interface TestWrapperProps {
+  navigation: Navigation;
+  children: React.ReactNode;
+}
+
+function TestWrapper({ children, navigation }: TestWrapperProps) {
+  return <NavigationContext.Provider value={navigation}>{children}</NavigationContext.Provider>;
+}
+
+describe('useNavigation hook', () => {
+  test('should return navigation', () => {
+    const { result } = renderHook(() => useNavigation(), {
+      wrapper: ({ children }) => <TestWrapper navigation={MOCK_NAVIGATION}>{children}</TestWrapper>,
+    });
+
+    expect(result.current).toEqual(MOCK_NAVIGATION);
+  });
+});

--- a/packages/toolpad-core/src/useNavigation/useNavigation.ts
+++ b/packages/toolpad-core/src/useNavigation/useNavigation.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import type { Navigation } from '../AppProvider';
+import { NavigationContext } from '../shared/context';
+
+/**
+ * Hook to access the current Toolpad Core navigation.
+ * @returns The current navigation.
+ */
+export function useNavigation(): Navigation {
+  return React.useContext(NavigationContext);
+}

--- a/packages/toolpad-core/vitest.config.base.mts
+++ b/packages/toolpad-core/vitest.config.base.mts
@@ -11,8 +11,10 @@ export default defineConfig({
       reportsDirectory: './.coverage',
       reporter: ['text', 'lcov'],
     },
-    deps: {
-      inline: ['@mui/x-data-grid'], // Fix CSS imports https://github.com/mui/mui-x/issues/17427
+    server: {
+      deps: {
+        inline: ['@mui/x-data-grid'], // Fix CSS imports https://github.com/mui/mui-x/issues/17427
+      },
     },
   },
 });


### PR DESCRIPTION
Closes https://github.com/mui/toolpad/issues/4939 which is getting quite a few thumbs up.

https://deploy-preview-4965--mui-toolpad-docs.netlify.app/toolpad/core/react-use-navigation/
https://deploy-preview-4965--mui-toolpad-docs.netlify.app/toolpad/core/react-use-navigation/api/