### PR TITLE
Add faIR language support for internationalization

### DIFF
--- a/packages/toolpad-core/src/locales/faIR.tsx
+++ b/packages/toolpad-core/src/locales/faIR.tsx
@@ -1,7 +1,7 @@
 import type { LocaleText } from '../AppProvider';
 import { getLocalization } from './getLocalization';
 
-const enLabels: LocaleText = {
+const faIRLabels: LocaleText = {
   // Account
   accountSignInLabel: 'ورود',
   accountSignOutLabel: 'خروج',
@@ -55,4 +55,4 @@ const enLabels: LocaleText = {
   deletedItemMessage: 'این مورد حذف شده است.',
 };
 
-export default getLocalization(enLabels);
+export default getLocalization(faIRLabels);

--- a/packages/toolpad-core/src/locales/faIR.tsx
+++ b/packages/toolpad-core/src/locales/faIR.tsx
@@ -1,0 +1,58 @@
+import type { LocaleText } from '../AppProvider';
+import { getLocalization } from './getLocalization';
+
+const enLabels: LocaleText = {
+  // Account
+  accountSignInLabel: 'ورود',
+  accountSignOutLabel: 'خروج',
+
+  // AccountPreview
+  accountPreviewTitle: 'حساب کاربری',
+  accountPreviewIconButtonLabel: 'کاربر فعلی',
+
+  // SignInPage
+  signInTitle: (brandingTitle?: string) =>
+    brandingTitle ? `ورود به ${brandingTitle}` : 'ورود',
+  signInSubtitle: 'کاربر گرامی، خوش آمدین، لطفا برای ادامه وارد حساب کاربری خود شوید',
+  signInRememberMe: 'من را را به خاطر بسپار',
+  providerSignInTitle: (provider: string) => `ورود با ${provider}`,
+
+  // Common authentication labels
+  email: 'رایانامه',
+  password: 'گذرواژه',
+  username: 'نام کاربری',
+  passkey: 'گذرکلید یا کلید عبور',
+
+  // Common action labels
+  save: 'ذخیره',
+  cancel: 'لغو',
+  ok: 'تایید',
+  or: 'یا',
+  to: 'به',
+  with: 'با',
+  close: 'بستن',
+  delete: 'حذف',
+  alert: 'هشدار',
+  confirm: 'تایید',
+  loading: 'بارگیری...',
+
+  // CRUD
+  createNewButtonLabel: 'ایجاد مورد جدید',
+  reloadButtonLabel: 'بارگیری مجدد داده‌ها',
+  createLabel: 'ایجاد',
+  createSuccessMessage: 'مورد فوق با موفقیت ایجاد شد.',
+  createErrorMessage: 'ایجاد مورد فوق ناموفق بود. به دلیل:',
+  editLabel: 'ویرایش',
+  editSuccessMessage: 'مورد فوق با موفیقت ویرایش شد.',
+  editErrorMessage: 'ایجاد مورد فوق ناموفق بود. به دلیل:',
+  deleteLabel: 'حذف',
+  deleteConfirmTitle: 'حذف مورد?',
+  deleteConfirmMessage: 'آیا مایل به حذف این مورد هستید؟',
+  deleteConfirmLabel: 'حذف',
+  deleteCancelLabel: 'لغو',
+  deleteSuccessMessage: 'مورد با موفقیت حذف شد.',
+  deleteErrorMessage: 'حذف مورد ناموفق بود. به دلیل:',
+  deletedItemMessage: 'این مورد حذف شده است.',
+};
+
+export default getLocalization(enLabels);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I've read and followed the [contributing guide](https://github.com/mui/toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [ ] I've updated the relevant documentation for any new or updated feature.
- [ ] I've linked relevant GitHub issue with "Closes #<issue id>".
- [ ] I've added a visual demonstration in the form of a screenshot or video.


I've just add Persian language support for internationalization with same name as it has in `@mui/material/locale` which is `faIR`